### PR TITLE
redux-devtools-extension support

### DIFF
--- a/src/client/redux/Store.js
+++ b/src/client/redux/Store.js
@@ -1,5 +1,5 @@
 import {createBrowserHistory} from 'history';
-import {createStore, applyMiddleware} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import reducer from './root.reducer';
 import {historyMiddleware} from './middleware';
 import {ON_LOCATION_CHANGE} from './router.reducer';
@@ -9,7 +9,8 @@ export default middleware => {
   const providedMiddleware = middleware ? middleware : [];
   middleware = [...providedMiddleware, historyMiddleware(history)];
 
-  const store = createStore(reducer, applyMiddleware(...middleware));
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  const store = createStore(reducer, composeEnhancers(applyMiddleware(...middleware)));
 
   // Redux-first routing is used as described:
   // https://medium.freecodecamp.org/an-introduction-to-the-redux-first-routing-model-98926ebf53cb


### PR DESCRIPTION
Jeg sidder og leger lidt med koden, og tænker om vi skal tilføje support for redux-devtools-extension?

Det er kun en mindre instrumentering af koden, og det er praktisk når man sidder og udvikler/debugger, eller blot dykker ned i koden, som jeg gør nu ;) Redux-devtools-extension er en browser extension hvor man kan se/debugge redux state og actions i browseren. Det kræver, at man eksponerer state'en, som I kan se her i pull-requesten, for at den kan bruges.