### PR TITLE
DISCUSSION: users in state

### DIFF
--- a/src/client/redux/__tests__/users.test.js
+++ b/src/client/redux/__tests__/users.test.js
@@ -1,0 +1,68 @@
+import {
+  REQUEST_USER,
+  RECEIVE_USER,
+  usersReducer,
+  usersMiddleware
+} from '../users';
+import Immutable from 'immutable';
+
+const request = require('superagent');
+
+describe('users', () => {
+  describe('reducer', () => {
+    it('REQUEST_USER action sets loading', () => {
+      expect(
+        usersReducer(new Immutable.Map(), {type: REQUEST_USER, id: 'userId'})
+      ).toEqual(Immutable.fromJS({userId: {loading: true}}));
+    });
+    it('REQUEST_USER action does nothing if already loading/loaded', () => {
+      const state = Immutable.fromJS({userId: true});
+      expect(usersReducer(state, {type: REQUEST_USER, id: 'userId'})).toEqual(
+        state
+      );
+    });
+    it('RECEIVE_USER sets user', () => {
+      expect(
+        usersReducer(Immutable.fromJS({userId: {loading: true}}), {
+          type: RECEIVE_USER,
+          id: 'userId',
+          user: {some: 'user'}
+        })
+      ).toEqual(Immutable.fromJS({userId: {some: 'user'}}));
+    });
+  });
+  describe('middleware', () => {
+    // Restore mocked functions
+    const requestGet = request.get;
+    afterEach(() => {
+      request.get = requestGet;
+    });
+
+    it('fetches user', async () => {
+      // Mock
+      let dispatched;
+      const promise = new Promise(resolve => {
+        dispatched = resolve;
+      });
+      const storeMock = {
+        getState: () => ({users: Immutable.fromJS({})}),
+        dispatch: action => {
+          expect(action).toEqual({
+            id: 'user/id',
+            type: RECEIVE_USER,
+            user: 'some user object'
+          });
+          dispatched();
+        }
+      };
+      request.get = async function requestMock(url) {
+        expect(url).toEqual('/v1/user/user%2Fid');
+        return {body: {data: 'some user object'}};
+      };
+
+      usersMiddleware(storeMock)(() => {})({type: REQUEST_USER, id: 'user/id'});
+
+      await promise;
+    });
+  });
+});

--- a/src/client/redux/root.reducer.js
+++ b/src/client/redux/root.reducer.js
@@ -4,6 +4,7 @@ import filterReducer from './filter.reducer';
 import routerReducer from './router.reducer';
 import workReducer from './work.reducer';
 import userReducer from './user.reducer';
+import {usersReducer} from './users';
 import tasteReducer from './taste.reducer';
 import listReducer from './list.reducer';
 import shortListReducer from './shortlist.reducer';
@@ -18,6 +19,7 @@ const combined = combineReducers({
   filterReducer,
   listReducer,
   userReducer: userReducer,
+  users: usersReducer,
   routerReducer,
   workReducer,
   shortListReducer,

--- a/src/client/redux/users.js
+++ b/src/client/redux/users.js
@@ -1,0 +1,66 @@
+/* eslint no-undefined:0 */
+import Immutable from 'immutable';
+import request from 'superagent';
+
+const defaultState = Immutable.fromJS({});
+
+export const REQUEST_USER = 'REQUEST_USER';
+export const RECEIVE_USER = 'RECEIVE_USER';
+
+//
+// Reducer
+//
+export function usersReducer(state = defaultState, action) {
+  switch (action.type) {
+    case REQUEST_USER:
+      return state.get(action.id, false)
+        ? state
+        : state.setIn([action.id, 'loading'], true);
+
+    case RECEIVE_USER:
+      return state.set(action.id, Immutable.fromJS(action.user));
+
+    default:
+      return state;
+  }
+}
+
+//
+// Middleware
+//
+export const usersMiddleware = store => next => action => {
+  switch (action.type) {
+    case REQUEST_USER:
+      if (!store.getState().users.getIn([action.id, 'loading'], false)) {
+        (async () => {
+          try {
+            const response = await request.get(
+              `/v1/user/${encodeURIComponent(action.id)}`
+            );
+            store.dispatch({
+              type: RECEIVE_USER,
+              id: action.id,
+              user: response.body.data
+            });
+          } catch (e) {
+            store.dispatch({
+              type: 'LOG_ERROR',
+              userId: action.id,
+              error: String(e),
+              msg: 'Error when fetching user'
+            });
+
+            // Clear user in state, such that we try to fetch it again, if we try again
+            store.dispatch({
+              type: RECEIVE_USER,
+              id: action.id,
+              user: undefined
+            });
+          }
+        })();
+      }
+      return next(action);
+    default:
+      return next(action);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,12 @@ import {
 } from './client/redux/middleware';
 import {tasteMiddleware} from './client/redux/taste.middleware';
 import {userMiddleware} from './client/redux/user.middleware';
+import {usersMiddleware} from './client/redux/users';
 import {orderMiddleware} from './client/redux/order.middleware';
 
 const store = createStore([
   userMiddleware,
+  usersMiddleware,
   requestMiddleware,
   tasteMiddleware,
   shortListMiddleware,


### PR DESCRIPTION
Users-delen af state'en tænkes at indeholde alle profil-data, og tanken er, at hver gang man i anden middleware henter data, der refererer til en user, så dispatcher man `REQUEST_USER`.

---

Vi talte for noget tid siden om at refaktorere state, så jeg har det i forbindelse med implementeringen #226, gjort det som det ville være mest naturligt for mig, fremfor helt at matche den eksisterende kodetilgang. Dette er et oplæg til diskussion om hvorledes vi griber redux/state an, - og vil derfor høre hvad i tænker om denne tilgang (ellers skrive jeg det bare om, så det matcher den eksisterende kodestil).

Forskelle fra eksisterende kode:

- reducer, middleware (og eventuelle selectors) ligger sammen, - hvis de var betydeligt mere komplicerede ville jeg splitte dem op i flere filer. Bruger bare `.js` og ikke `.reducer.js` extension.
- tilstanden hedder `users` i state og ikke `usersReducer`

Bemærk også måden at koden håndterer race-conditions på: Hvis der dispatches flere `REQUEST` actions, undervejs mens den er ved, at hente data fra serveren, laver det ikke rod i tilstanden, - og der er en midlertidig tilstand for som eventuelt kan bruges til vise en load-spinner. Mener at have set i andre dele af koden, at vi kan have race-conditions i ligenende situationer.
