### PR TITLE
#201 /object-endpoint result should have _id and _rev instead of ok, …

### DIFF
--- a/src/integration/v1-object_test.js
+++ b/src/integration/v1-object_test.js
@@ -52,12 +52,8 @@ describe('User data', () => {
           .post(url + '/object')
           .set('cookie', cookieUser1)
           .send(list)).body.data;
-        expect(Object.keys(result)).to.deep.equal(['ok', 'id', 'rev']);
-        Object.assign(list, {
-          _rev: result.rev,
-          _id: result.id,
-          _owner: user1.openplatformId
-        });
+        expect(Object.keys(result)).to.deep.equal(['_id', '_rev']);
+        Object.assign(list, result, {_owner: user1.openplatformId});
       }
 
       // We can fetch the list, even as anonymous user as it is public.

--- a/src/lib/services/elvis/community.js
+++ b/src/lib/services/elvis/community.js
@@ -679,7 +679,7 @@ class Community {
       const entityUrl = await this.gettingPostEntityUrl();
       await request.post(entityUrl).send(entity);
     }
-    return {data: {ok: true, id: object._id, rev: object._rev}};
+    return {data: {_id: object._id, _rev: object._rev}};
   }
 
   async getObjectById(id, user = {}) {

--- a/src/lib/services/elvis/community_test.js
+++ b/src/lib/services/elvis/community_test.js
@@ -517,8 +517,7 @@ describe('Community connector', () => {
           object: {foo: 'bar', key: 'baz'},
           user
         });
-        expect(Object.keys(result.data)).to.deep.equal(['ok', 'id', 'rev']);
-        expect(result.data.ok).to.equal(true);
+        expect(Object.keys(result.data)).to.deep.equal(['_id', '_rev']);
       });
       it('should return not-found if _id is present, and no previous object', async () => {
         arrangeQueryObjectNotFound();
@@ -626,7 +625,7 @@ describe('Community connector', () => {
           user
         });
         expect(result).to.deep.equal({
-          data: {id: 'some_id', ok: true, rev: contentsObj._rev}
+          data: {_id: 'some_id', _rev: contentsObj._rev}
         });
       });
     });


### PR DESCRIPTION
…id and rev