### PR TITLE
Filterside redesign (part 1)

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -14,7 +14,6 @@ import ProfilePage from './components/profile/ProfilePage.container';
 import Bookcase from './components/bookcase/Bookcase.component';
 import CreateProfilePage from './components/profile/CreateProfilePage';
 import TopBar from './components/top/TopBar.component';
-import {beltNameToPath} from './utils/belt';
 import {ON_USER_DETAILS_REQUEST} from './redux/user.reducer';
 import ListPage from './components/list/ListPage.container';
 import ListCreator from './components/list/ListCreate.container';
@@ -68,13 +67,8 @@ class App extends Component {
       currentPage = <SearchPage />;
     } else if (pathSplit[1] === 'bogreol') {
       currentPage = <Bookcase />;
-    } else {
-      // check if current path matches a belt
-      this.props.beltsState.belts.forEach(belt => {
-        if (beltNameToPath(belt.name) === path) {
-          currentPage = <FilterPage belt={belt} />;
-        }
-      });
+    } else if (pathSplit[1] === 'find') {
+      currentPage = <FilterPage />;
     }
 
     if (!currentPage) {

--- a/src/client/components/belt/BooksBelt.container.js
+++ b/src/client/components/belt/BooksBelt.container.js
@@ -6,7 +6,7 @@ import Slider from '../belt/Slider.component';
 import {RECOMMEND_REQUEST} from '../../redux/recommend';
 import {getRecommendedBooks} from '../../redux/selectors';
 import {filtersMapAll} from '../../redux/filter.reducer';
-import {beltNameToPath} from '../../utils/belt';
+import Link from '../general/Link.component';
 
 export class BooksBelt extends React.Component {
   constructor() {
@@ -40,17 +40,19 @@ export class BooksBelt extends React.Component {
     return (
       <div className="row belt text-left">
         <div className="col-xs-12 header">
-          <span
-            className="belt-title"
-            data-html="true"
-            data-toggle="tooltip"
-            data-original-title={this.getTooltipText(this.props.tagObjects)}
-            onClick={() =>
-              this.props.historyPush(beltNameToPath(this.props.title))
-            }
+          <Link
+            href="/find"
+            params={{tag: this.props.tagObjects.map(t => t.id)}}
           >
-            {this.props.title}
-          </span>
+            <span
+              className="belt-title"
+              data-html="true"
+              data-toggle="tooltip"
+              data-original-title={this.getTooltipText(this.props.tagObjects)}
+            >
+              {this.props.title}
+            </span>
+          </Link>
         </div>
 
         {this.props.recommendedBooks && (

--- a/src/client/components/filter/FilterPage.container.js
+++ b/src/client/components/filter/FilterPage.container.js
@@ -99,7 +99,9 @@ class FilterPage extends React.Component {
 }
 const mapStateToProps = state => {
   const selectedTagIds = state.routerReducer.params.tag
-    ? state.routerReducer.params.tag.map(tag => parseInt(tag, 10))
+    ? state.routerReducer.params.tag
+        .map(id => parseInt(id, 10))
+        .filter(id => filtersMapAll[id])
     : [];
   return {
     recommendations: getRecommendedBooks(state, selectedTagIds, 40),

--- a/src/client/components/general/Link.component.js
+++ b/src/client/components/general/Link.component.js
@@ -7,16 +7,17 @@ const Link = ({
   className = '',
   children = '',
   dispatch,
-  replace = false
+  replace = false,
+  params = {}
 }) => (
   <a
     className={className}
     href={href}
     onClick={e => {
       if (replace) {
-        dispatch({type: HISTORY_REPLACE, path: href});
+        dispatch({type: HISTORY_REPLACE, path: href, params});
       } else {
-        dispatch({type: HISTORY_PUSH, path: href});
+        dispatch({type: HISTORY_PUSH, path: href, params});
       }
       e.preventDefault();
     }}

--- a/src/client/components/list/ListCard.component.js
+++ b/src/client/components/list/ListCard.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TruncateMarkup from 'react-truncate-markup';
 import BookCover from '../general/BookCover.component';
 import ProfileImage from '../general/ProfileImage.component';
-import {Likes, Comments, Badge} from '../general/Icons';
+import {Badge} from '../general/Icons';
 import Link from '../general/Link.component';
 
 class ListCard extends React.PureComponent {

--- a/src/client/components/work/WorkPage.container.js
+++ b/src/client/components/work/WorkPage.container.js
@@ -7,9 +7,8 @@ import CheckmarkConnected from '../general/CheckmarkConnected.component';
 import BookCover from '../general/BookCover.component';
 import OrderButton from '../order/OrderButton.component';
 import Slider from '../belt/Slider.component';
+import Link from '../general/Link.component';
 import {ON_WORK_REQUEST} from '../../redux/work.reducer';
-import {HISTORY_PUSH} from '../../redux/middleware';
-import {ON_RESET_FILTERS} from '../../redux/filter.reducer';
 import {getLeaves} from '../../utils/taxonomy';
 
 import {getListsForOwner, SYSTEM_LIST} from '../../redux/list.reducer';
@@ -143,23 +142,14 @@ class WorkPage extends React.Component {
                       {group.data.map(t => {
                         if (allowedFilterIds.indexOf(t.id) >= 0) {
                           return (
-                            <span
-                              key={t.id}
+                            <Link
                               className="tag active"
-                              onClick={() => {
-                                this.props.dispatch({
-                                  type: ON_RESET_FILTERS,
-                                  beltName: 'Passer med min smag'
-                                });
-                                this.props.dispatch({
-                                  type: HISTORY_PUSH,
-                                  path: '/passer-med-min-smag',
-                                  params: {filter: t.id}
-                                });
-                              }}
+                              key={t.id}
+                              href="/find"
+                              params={{tag: t.id}}
                             >
                               {t.title}
-                            </span>
+                            </Link>
                           );
                         }
                         return (


### PR DESCRIPTION
#310
- filtersiden har fået fast path: /find
- afkoblet fra bånd på forsiden (dropdown er fjernet), så nu er det kun tag-id'er i url query parameter der søges ud fra.