### PR TITLE
old list upgrade to bookcase

### DIFF
--- a/src/client/redux/__tests__/list.reducer.test.js
+++ b/src/client/redux/__tests__/list.reducer.test.js
@@ -1,6 +1,7 @@
 import listReducer, {
   addList,
   getLists,
+  getListById,
   getListsForOwner,
   removeList,
   addElementToList,
@@ -12,6 +13,29 @@ import listReducer, {
 } from '../list.reducer';
 
 describe('listReducer', () => {
+  test('add position to list elements if none given', () => {
+    let state = listReducer(
+      {lists: {}},
+      addList({
+        title: 'some list 1',
+        type: CUSTOM_LIST,
+        id: 'some-id-1',
+        _created: '1234'
+      })
+    );
+    state = listReducer(
+      state,
+      addElementToList(
+        {
+          book: {pid: 'pid1'},
+          description: 'some-description-1'
+        },
+        'some-id-1'
+      )
+    );
+    // Expects, if a book dont have a position, a position will be added in LIST_LOAD_RESPONSE
+    expect(getListById(state, 'some-id-1').list[0].position);
+  });
   test('add list throws when id is missing', () => {
     expect(() => {
       listReducer(

--- a/src/client/redux/list.reducer.js
+++ b/src/client/redux/list.reducer.js
@@ -222,9 +222,19 @@ const listReducer = (state = defaultState, action) => {
         return map;
       }, {});
       const listMap = {};
+
       lists.forEach(l => {
-        listMap[l.id] = l;
+        l.list.map(element => {
+          if (!element.position) {
+            element.position = {
+              x: Math.floor(Math.random() * Math.floor(100)),
+              y: Math.floor(Math.random() * Math.floor(100))
+            };
+          }
+        });
+        return (listMap[l.id] = l);
       });
+
       return Object.assign({}, state, {
         lists: listMap,
         changeMap
@@ -421,6 +431,7 @@ export const getPublicLists = state => {
 export const getListById = (state, id) => {
   return state.lists[id];
 };
+
 const validateId = (state, action) => {
   if (!action.id) {
     throw new Error("'id' is not defined");

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import {usersMiddleware} from './client/redux/users';
 import {orderMiddleware} from './client/redux/order.middleware';
 import {recommendMiddleware} from './client/redux/recommend';
 import {commentMiddleware} from './client/redux/comment.middleware';
-import {replayMiddleware} from './client/redux/replay'
+import {replayMiddleware} from './client/redux/replay';
 
 const store = createStore([
   userMiddleware,


### PR DESCRIPTION
Løser issue #418 

Bøger som allerede er tilføjet til en visuel el. simpel liste, har ikke en position key på sig. Ændre man en liste til en bogreol vil bøgerne springe rundt på siden, til de får en position key. 

Dette pr sikre at alle bøger på lister får en default random position ved indlæsningen. LIST_LOAD_RESPONSE