### PR TITLE
404 content-first not working in IE11

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,9 +29,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <!-- Polyfills for IE compatibility -->
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6"></script>
-
     <!--Bootstrap-->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <!-- jQuery library -->


### PR DESCRIPTION
løser issue #404 

- Polyfill importeres 2 gange, både i index.html (<script>) og i index.js (import). Dette resultere i en "values-er-allerede-defineret" fejl 2. gang polyfill indlæses, og forhindre hele siden i at blive indlæst.

Polyfill er fjernet i index.html. 