### PR TITLE
Flyt objekt-endpointet til content-first databasen fra community-servicen

### DIFF
--- a/src/acceptance/1-object_test.js
+++ b/src/acceptance/1-object_test.js
@@ -1,0 +1,258 @@
+/* eslint-env mocha */
+'use strict';
+
+const mock = require('fixtures/mock-server');
+const {expect} = require('chai');
+const request = require('supertest');
+const _ = require('lodash');
+
+describe('Endpoint /v1/object', () => {
+  const webapp = request(mock.external);
+  const cookie1 = 'login-token=valid-login-token-for-user-seeded-on-test-start';
+  const cookie2 =
+    'login-token=valid-login-token-for-user2-seeded-on-test-start';
+  const id1 = '123openplatformId456';
+  const id2 = '123openplatformId2';
+
+  // test objects
+  const objects = [
+    [cookie1, {_type: 'test', text: 'object0', _public: false}],
+    [cookie1, {_type: 'test', _key: 'hi', _public: true}],
+    [cookie1, {_type: 'test', _key: 'ho', some: 'property', _public: true}],
+    [cookie2, {_type: 'test', _key: 'hi', _public: true, other: 'property'}],
+    [cookie2, {_type: 'test', _key: 'hi', Im: 'private'}],
+    [cookie1, {_type: 'test', _key: 'hi', _public: true}],
+    [cookie1, {_type: 'test'}]
+  ];
+  // _ids of test objects in database
+  let objectResults;
+
+  beforeEach(async () => {
+    await mock.resetting();
+
+    // add test objects sequentially, as we otherwise may run out of postgres connections
+    objectResults = [];
+    for (const [cookie, obj] of objects) {
+      objectResults.push({
+        cookie,
+        _id: (await webapp
+          .post('/v1/object')
+          .set('cookie', cookie)
+          .send(obj)).body.data._id
+      });
+    }
+  });
+  afterEach(async () => {
+    // delete test objects from database
+    for (const {cookie, _id} of objectResults) {
+      await webapp.del('/v1/object/' + _id).set('cookie', cookie);
+    }
+  });
+  describe('Public endpoint', () => {
+    describe('GET /v1/object/:pid', () => {
+      it('should retrieve object', async () => {
+        const id = objectResults[0]._id;
+        const result = (await webapp
+          .get(`/v1/object/${id}`)
+          .set('cookie', cookie1)).body;
+        const object = _.omit(result.data, ['_created', '_modified', '_rev']);
+        expect(object).to.deep.equal({
+          text: 'object0',
+          _id: id,
+          _key: '',
+          _owner: id1,
+          _public: false,
+          _type: 'test'
+        });
+        expect(result.errors).to.be.an('undefined');
+      });
+      it('fails with 404 when it does not exist', async () => {
+        const result = await webapp
+          .get(`/v1/object/c71b92a0-6b0d-11e8-bf34-dfd6f8cd7d98`)
+          .set('cookie', cookie1);
+        expect(result.status).to.equal(404);
+        expect(result.body).to.deep.equal({
+          data: {error: 'not found'},
+          errors: [{status: 404, message: 'not found'}]
+        });
+      });
+      it('fails with 403 when it does not have read rights', async () => {
+        const id = objectResults[0]._id;
+        const result = await webapp
+          .get(`/v1/object/${id}`)
+          .set('cookie', cookie2);
+        expect(result.status).to.equal(403);
+        expect(result.body).to.deep.equal({
+          data: {error: 'forbidden'},
+          errors: [{status: 403, message: 'forbidden'}]
+        });
+      });
+    });
+    describe('GET /v1/object/find', () => {
+      it('find objects all public objects of given type', async () => {
+        const result = (await webapp
+          .get(`/v1/object/find?type=test`)
+          .set('cookie', cookie2)).body;
+        expect(result.errors).to.be.an('undefined');
+        expect(result.data.length).to.equal(4);
+      });
+      it('find objects all own objects of given type', async () => {
+        const result = (await webapp
+          .get(`/v1/object/find?type=test&owner=${id2}`)
+          .set('cookie', cookie2)).body;
+        expect(result.errors).to.be.an('undefined');
+        expect(result.data.length).to.equal(2);
+      });
+      it('find all public objects of given type+user+key', async () => {
+        const result = (await webapp
+          .get(`/v1/object/find?type=test&owner=${id2}&key=hi`)
+          .set('cookie', cookie1)).body;
+        expect(result.errors).to.be.an('undefined');
+        expect(result.data.length).to.equal(1);
+      });
+      it('find objects all public objects of given type+key', async () => {
+        const result = (await webapp
+          .get(`/v1/object/find?type=test&key=hi`)
+          .set('cookie', cookie2)).body;
+        expect(result.errors).to.be.an('undefined');
+        expect(result.data.length).to.equal(3);
+      });
+      it('find no objects', async () => {
+        const result = (await webapp
+          .get(`/v1/object/find?type=test&key=nonexistant`)
+          .set('cookie', cookie2)).body;
+        expect(result.errors).to.be.an('undefined');
+        expect(result.data.length).to.equal(0);
+      });
+    });
+    describe('DELETE /v1/object/:pid', () => {
+      it('successful deletes', async () => {
+        const id = objectResults[1]._id;
+        let result = await webapp
+          .get(`/v1/object/${id}`)
+          .set('cookie', cookie1);
+        expect(result.status).to.equal(200);
+        result = await webapp.delete(`/v1/object/${id}`).set('cookie', cookie1);
+        expect(result.status).to.equal(200);
+        expect(result.body).to.deep.equal({data: {ok: true}});
+        result = await webapp.get(`/v1/object/${id}`).set('cookie', cookie1);
+        expect(result.status).to.equal(404);
+      });
+      it('returns forbidden when not owner', async () => {
+        const id = objectResults[1]._id;
+        const result = await webapp
+          .delete(`/v1/object/${id}`)
+          .set('cookie', cookie2);
+        expect(result.status).to.equal(403);
+        expect(result.body).to.deep.equal({
+          data: {error: 'forbidden'},
+          errors: [{status: 403, message: 'forbidden'}]
+        });
+      });
+      it('returns 404 when not found', async () => {
+        const result = await webapp
+          .delete(`/v1/object/c71b92a0-6b0d-11e8-bf34-dfd6f8cd7d98`)
+          .set('cookie', cookie2);
+        expect(result.status).to.equal(404);
+        expect(result.body).to.deep.equal({
+          data: {error: 'not found'},
+          errors: [{status: 404, message: 'not found'}]
+        });
+      });
+    });
+    describe('POST /v1/object', () => {
+      it('create new object', async () => {
+        const result = (await webapp
+          .post('/v1/object')
+          .set('cookie', cookie1)
+          .send({_type: 'test', _key: '123', hello: 'world'})).body;
+        expect(Object.keys(result.data)).to.deep.equal(['_id', '_rev']);
+        expect(result.errors).to.be.an('undefined');
+
+        let obj = (await webapp
+          .get(`/v1/object/${result.data._id}`)
+          .set('cookie', cookie1)).body.data;
+        expect(obj.hello).to.equal('world');
+      });
+      it('change an object', async () => {
+        const id = objectResults[0]._id;
+        let obj = (await webapp.get(`/v1/object/${id}`).set('cookie', cookie1))
+          .body.data;
+        obj.changed = true;
+
+        const result = await webapp
+          .post('/v1/object')
+          .set('cookie', cookie1)
+          .send(obj);
+        expect(result.status).to.equal(200);
+        expect(result.body.data._id).to.equal(obj._id);
+        expect(result.body.data._rev).to.be.a('string');
+
+        let newObj = (await webapp
+          .get(`/v1/object/${id}`)
+          .set('cookie', cookie1)).body.data;
+        expect(newObj.changed).to.equal(true);
+        expect(newObj._rev).to.equal(result.body.data._rev);
+      });
+    });
+    describe('PUT /v1/object/:pid', () => {
+      it('overwrite object', async () => {
+        const id = objectResults[0]._id;
+        const result = (await webapp
+          .put(`/v1/object/${id}`)
+          .set('cookie', cookie1)
+          .send({_type: 'test', _key: '123', hi: 'world', _public: true})).body;
+        const getResult = (await webapp.get(`/v1/object/${id}`)).body;
+        const object = _.omit(getResult.data, [
+          '_created',
+          '_modified',
+          '_rev'
+        ]);
+        expect(object).to.deep.equal({
+          hi: 'world',
+          _id: id,
+          _key: '123',
+          _owner: id1,
+          _public: true,
+          _type: 'test'
+        });
+        expect(result.errors).to.be.an('undefined');
+      });
+      it('fails with wrong revision', async () => {
+        const id = objectResults[0]._id;
+        const result = await webapp
+          .put(`/v1/object/${id}`)
+          .set('cookie', cookie1)
+          .send({_type: 'test', _rev: 'wrong-revision', _key: '123'});
+        expect(result.status).to.equal(409);
+        expect(result.body).to.deep.equal({
+          data: {error: 'conflict'},
+          errors: [{status: 409, message: 'conflict'}]
+        });
+      });
+      it('fails with user now owning the object', async () => {
+        const id = objectResults[1]._id;
+        const result = await webapp
+          .put(`/v1/object/${id}`)
+          .set('cookie', cookie2)
+          .send({_type: 'test', _key: '123', hi: 'world', _public: true});
+        expect(result.status).to.equal(403);
+        expect(result.body).to.deep.equal({
+          data: {error: 'forbidden'},
+          errors: [{status: 403, message: 'forbidden'}]
+        });
+      });
+      it('fails with non-existing object', async () => {
+        const result = await webapp
+          .put(`/v1/object/c71b92a0-6b0d-11e8-bf34-dfd6f8cd7d98`)
+          .set('cookie', cookie2)
+          .send({_type: 'test', _key: '123', hi: 'world', _public: true});
+        expect(result.status).to.equal(404);
+        expect(result.body).to.deep.equal({
+          data: {error: 'not found'},
+          errors: [{status: 404, message: 'not found'}]
+        });
+      });
+    });
+  });
+});

--- a/src/acceptance/v1-stats_test.js
+++ b/src/acceptance/v1-stats_test.js
@@ -36,7 +36,7 @@ describe('Statistics API', () => {
               expectValidate(data, 'schemas/statistics-out.json');
               // Only one of the seeded cookies should survive implicit
               // cleanup done by /stats.
-              expect(data.users['logged-in']).to.equal(1);
+              expect(data.users['logged-in']).to.equal(2);
               // Books & Tags.
               expect(data.books.total).to.equal(2);
               expect(data.tags.total).to.equal(52);

--- a/src/integration/v1-object_test.js
+++ b/src/integration/v1-object_test.js
@@ -4,6 +4,7 @@
 const mock = require('fixtures/mock-server');
 const seeder = require('./seed-community');
 const supertest = require('supertest');
+const _ = require('underscore');
 
 const chai = require('chai');
 const expect = require('chai').expect;
@@ -44,6 +45,7 @@ describe('User data', () => {
         list = {
           _type: 'list',
           _public: true,
+          _key: '',
           writable: true,
           description: 'some list description',
           children: []
@@ -62,7 +64,7 @@ describe('User data', () => {
       delete dbList._created;
       chai.assert(dbList._modified);
       delete dbList._modified;
-      expect(dbList).to.deep.equal(list);
+      expect(dbList).to.deep.equal(_.omit(list, ['_created', '_modified']));
 
       // anonymous cannot add list entries
       result = await request.post(url + '/object').send({
@@ -112,15 +114,6 @@ describe('User data', () => {
       expect(result.text).to.equal(
         '{"data":{"error":"forbidden"},"errors":[{"status":403,"message":"forbidden"}]}'
       );
-
-      // user 1 can change the list
-      list.children = [listEntries[1]._id];
-      list.blacklist = [listEntries[0]._id];
-      result = await request
-        .put(url + '/object/' + list._id)
-        .set('cookie', cookieUser1)
-        .send(list);
-      expect(result.statusCode).to.equal(200);
     });
   });
 });

--- a/src/migrations/20180606100000_objects.js
+++ b/src/migrations/20180606100000_objects.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const constants = require('server/constants')();
+const objectsTable = constants.objects.table;
+
+exports.up = function(knex) {
+  return knex.schema.createTable(objectsTable, table => {
+    table.uuid('id').primary();
+    table.string('rev').notNullable();
+    table.string('owner').notNullable();
+    table.string('type').notNullable();
+    table.string('key').notNullable();
+    table.boolean('public').notNullable();
+    table.integer('created').notNullable();
+    // seconds since 1970
+    table.integer('modified').notNullable();
+    table.json('data').notNullable();
+    table.index(['type', 'key', 'modified']);
+    table.index(['owner', 'type', 'key', 'modified']);
+  });
+};
+
+exports.down = function() {
+  return Promise.resolve();
+};

--- a/src/seeds/seed-db.js
+++ b/src/seeds/seed-db.js
@@ -74,6 +74,12 @@ exports.seed = async knex => {
     expires_epoch_s: Math.ceil(Date.now() / 1000) + 10000
   });
   await knex(cookieTable).insert({
+    cookie: 'valid-login-token-for-user2-seeded-on-test-start',
+    community_profile_id: 234566,
+    openplatform_id: '123openplatformId2',
+    expires_epoch_s: Math.ceil(Date.now() / 1000) + 10000
+  });
+  await knex(cookieTable).insert({
     cookie: 'expired-login-token',
     community_profile_id: 123456,
     openplatform_id: '123openplatformId456',

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -34,6 +34,9 @@ const constants = {
   },
   users: {
     table: 'users'
+  },
+  objects: {
+    table: 'objects'
   }
 };
 

--- a/src/server/external-v1-object.js
+++ b/src/server/external-v1-object.js
@@ -30,9 +30,13 @@ async function putObject(req, res) {
 async function findObject(req, res) {
   send(res, await objectStore.find(req.query, await getUser(req)));
 }
+async function deleteObject(req, res) {
+  send(res, await objectStore.del(req.params.id, await getUser(req)));
+}
 
 router.route('/find').get(asyncMiddleware(findObject));
 router.route('/:id').get(asyncMiddleware(getObject));
 router.route('/:id').put(asyncMiddleware(putObject));
 router.route('/').post(asyncMiddleware(putObject));
+router.route('/:id').delete(asyncMiddleware(deleteObject));
 module.exports = router;

--- a/src/server/objectStore.js
+++ b/src/server/objectStore.js
@@ -3,10 +3,13 @@
 const assert = require('assert');
 const community = require('server/community');
 
+const _ = require('lodash');
 const config = require('server/config');
 const knex = require('knex')(config.db);
 const constants = require('server/constants')();
 const cookieTable = constants.cookies.table;
+const objectTable = constants.objects.table;
+const uuidGenerator = require('uuid');
 
 async function getUser(req) {
   const loginToken = req.cookies['login-token'];
@@ -26,17 +29,202 @@ async function getUser(req) {
   return;
 }
 
-function get(id, user = {}) {
-  return community.getObjectById(id, user);
+const rowToObject = o => ({
+  ...o.data,
+  _id: o.id,
+  _rev: o.rev,
+  _owner: o.owner,
+  _type: o.type,
+  _key: o.key,
+  _public: o.public,
+  _created: o.created,
+  _modified: o.modified
+});
+
+async function writeObject(o) {
+  await knex(objectTable).insert({
+    id: o._id,
+    rev: o._rev,
+    owner: o._owner,
+    type: o._type || '',
+    key: o._key || '',
+    public: !!o._public,
+    created: o._created,
+    modified: o._modified,
+    data: _.omitBy(o, (v, k) => k.startsWith('_'))
+  });
 }
 
-function put(object, user) {
+async function get(id, user = {}) {
+  const results = await knex(objectTable)
+    .where('id', id)
+    .select();
+  if (results.length > 0) {
+    const object = rowToObject(results[0]);
+    if (!object._public && object._owner !== user.openplatformId) {
+      return {
+        data: {error: 'forbidden'},
+        errors: [{status: 403, message: 'forbidden'}]
+      };
+    }
+    return {data: object};
+  }
+
+  // TODO: remove this when old data is migrated
+  const communityResult = await community.getObjectById(id, user);
+  if (!communityResult.errors) {
+    await writeObject(communityResult.data);
+  }
+  if (communityResult) {
+    return communityResult;
+  }
+  // end migrate old data
+
+  return {
+    data: {error: 'not found'},
+    errors: [{status: 404, message: 'not found'}]
+  };
+}
+
+async function put(object, user) {
   assert(user);
-  return community.putObject({object, user});
+  assert(user.openplatformId);
+
+  const revision =
+    Date.now() +
+    '-' +
+    Math.random()
+      .toString(36)
+      .slice(2);
+  const epoch = (Date.now() / 1000) | 0;
+
+  if (object._id) {
+    const prev = await get(object._id, user);
+    if (prev.errors) {
+      return prev;
+    }
+    const prevObj = prev.data;
+    if (prevObj._owner !== user.openplatformId) {
+      return {
+        data: {error: 'forbidden'},
+        errors: [{status: 403, message: 'forbidden'}]
+      };
+    }
+
+    let updateQuery = knex(objectTable).where('id', object._id);
+    if (object._rev) {
+      updateQuery = updateQuery.where('rev', object._rev);
+    }
+    const result = await updateQuery
+      .update({
+        rev: revision,
+        type: object._type || '',
+        key: object._key || '',
+        public: !!object._public,
+        modified: epoch,
+        data: _.omitBy(object, (v, k) => k.startsWith('_'))
+      })
+      .returning(['id', 'rev']);
+    if (result.length === 0) {
+      return {
+        data: {error: 'conflict'},
+        errors: [{status: 409, message: 'conflict'}]
+      };
+    }
+    return {data: {_id: result[0].id, _rev: result[0].rev}};
+  }
+
+  object = {
+    ...object,
+    _id: uuidGenerator.v1(),
+    _rev: revision,
+    _owner: user.openplatformId,
+    _created: epoch,
+    _modified: epoch
+  };
+  await writeObject(object);
+  return {data: {_id: object._id, _rev: object._rev}};
 }
 
-function find(query, user = {}) {
-  return community.findObjects(query, user);
+async function find(query, user = {}) {
+  query = Object.assign(
+    {
+      limit: 20,
+      offset: 0
+    },
+    query
+  );
+
+  if (!query.type) {
+    throw new Error('Query Error');
+  }
+  let knexQuery = knex(objectTable);
+
+  if (typeof query.type !== 'undefined') {
+    knexQuery = knexQuery.where('type', query.type);
+  }
+  if (typeof query.key !== 'undefined') {
+    knexQuery = knexQuery.where('key', query.key);
+  }
+  if (typeof query.owner !== 'undefined') {
+    knexQuery = knexQuery.where('owner', query.owner);
+  }
+  if (!query.owner || query.owner !== user.openplatformId) {
+    knexQuery = knexQuery.where('public', true);
+  }
+
+  let result = await knexQuery
+    .orderBy('type')
+    .orderBy('key')
+    .orderBy('modified', 'desc')
+    .select();
+  result = result.map(rowToObject);
+
+  // TODO: remove this when old data is migrated
+  let oldResult = (await community.findObjects(query, user)).data;
+  const resultIds = result.map(o => o.id);
+  oldResult = oldResult.filter(o => !resultIds.includes(o._id));
+  for (const object of oldResult) {
+    if (
+      (await knex(objectTable)
+        .where('id', object._id)
+        .select()).length === 0
+    ) {
+      await writeObject(object);
+    }
+  }
+  result = result.concat(oldResult);
+  result.sort((a, b) => (a.modified < b.modified ? 1 : -1));
+  result = result.slice(0, query.limit);
+  // end migrate old data
+
+  return {data: result};
 }
 
-module.exports = {getUser, get, put, find};
+async function del(id, user) {
+  const result = await get(id, user);
+
+  if (result.errors) {
+    return {
+      data: {error: 'not found'},
+      errors: [{status: 404, message: 'not found'}]
+    };
+  }
+
+  const {data: {_owner}} = result;
+  if (_owner !== user.openplatformId) {
+    return {
+      data: {error: 'forbidden'},
+      errors: [{status: 403, message: 'forbidden'}]
+    };
+  }
+  await knex(objectTable)
+    .where('id', id)
+    .del();
+
+  return {
+    data: {ok: true}
+  };
+}
+
+module.exports = {getUser, get, put, find, del};


### PR DESCRIPTION
Del af GDPR #430.

Flytter objekt-endpointet til at bruge content-first databasen. Henter og migrerer data fra community-servicen når de tilgås, hvis de ikke allerede er flyttet til content-first-databasen.

Coverage går lidt ned, da den nye implementation skygger over dele af den gamle, som så ikke længere bliver testet.