### PR TITLE
bug workaround.

### DIFF
--- a/src/client/utils/requester.js
+++ b/src/client/utils/requester.js
@@ -31,10 +31,12 @@ export const fetchTags = async (pids = []) => {
   for (var x = 0; x < requests.length; x++) {
     const req = requests[x];
     const response = await req.request;
-    const tags = response.body.data.tags
-      .map(t => taxonomyMap[t])
-      .filter(t => t);
-    result[req.pid] = tags;
+    if (req.request.body) {
+      const tags = response.body.data.tags
+        .map(t => taxonomyMap[t])
+        .filter(t => t);
+      result[req.pid] = tags;
+    }
   }
 
   return result;


### PR DESCRIPTION
I visse tilfælde kaldes fetchTags med en invalid pid, denne kode ignorerer dette i stedet for at grænsefladen brager ned.

Jeg tror at kilden til at invalide pids er rettet, men de kan stadigt ligge i brugerdata.