### PR TITLE
use list._id instead of list.id

### DIFF
--- a/src/client/components/general/AddToListButton.component.js
+++ b/src/client/components/general/AddToListButton.component.js
@@ -143,7 +143,7 @@ export class AddToListButton extends React.Component {
                     <li
                       key={list.title}
                       onClick={() => {
-                        this.props.toggleInList(work, list.id);
+                        this.props.toggleInList(work, list._id);
                         toast(
                           <ToastMessage
                             type="success"
@@ -178,7 +178,7 @@ export class AddToListButton extends React.Component {
                   <li
                     key={list.title}
                     onClick={() => {
-                      this.props.toggleInList(work, list.id);
+                      this.props.toggleInList(work, list._id);
                       toast(
                         <ToastMessage
                           type="success"

--- a/src/client/components/list/AddToList.container.js
+++ b/src/client/components/list/AddToList.container.js
@@ -86,8 +86,8 @@ const mapStateToProps = (state, ownProps) => {
 };
 export const mapDispatchToProps = dispatch => ({
   addElement: async (book, list) => {
-    await dispatch(addElementToList(book, list.id));
-    dispatch(storeList(list.id));
+    await dispatch(addElementToList(book, list._id));
+    dispatch(storeList(list._id));
   },
   requireLogin: () => {
     dispatch({

--- a/src/client/components/list/ListCard.component.js
+++ b/src/client/components/list/ListCard.component.js
@@ -25,7 +25,7 @@ class ListCard extends React.Component {
   }
 
   updateComments() {
-    this.props.fetchComments(this.props.list.id);
+    this.props.fetchComments(this.props.list._id);
 
     if (this.props.list.list && this.props.list.list.length > 0) {
       this.props.list.list.forEach(el => {
@@ -57,11 +57,11 @@ class ListCard extends React.Component {
     if (!this.props.skeleton) {
       if (
         this.props.comments &&
-        this.props.comments[list.id] &&
-        this.props.comments[list.id].comments
+        this.props.comments[list._id] &&
+        this.props.comments[list._id].comments
       ) {
         // count comments for list
-        commentCount = this.props.comments[list.id].comments.length;
+        commentCount = this.props.comments[list._id].comments.length;
         if (this.props.list.list && this.props.list.list.length > 0) {
           this.props.list.list.forEach(el => {
             const elementComments = this.props.comments[el._key + '-' + el.pid];
@@ -91,10 +91,10 @@ class ListCard extends React.Component {
 
     return (
       <div className={'list-card mr1 ml1 ' + className} style={style}>
-        <Link href={`/lister/${list.id}`}>
+        <Link href={`/lister/${list._id}`}>
           <div className="list-card-wrap">
             <div className="list-card-cover">
-              {this.renderBookCover(list.id, list.image)}
+              {this.renderBookCover(list._id, list.image)}
             </div>
             <div className="list-card-summary">
               <Heading
@@ -114,7 +114,7 @@ class ListCard extends React.Component {
             </div>
             <div className="list-card-bottom">
               <ProfileImage
-                key={'profile-img-' + list.id}
+                key={'profile-img-' + list._id}
                 user={this.props.profile}
                 namePosition={'right'}
                 type="list"

--- a/src/client/components/list/ListCreate.container.js
+++ b/src/client/components/list/ListCreate.container.js
@@ -44,7 +44,7 @@ const ListBooks = props => (
   <div className="list-drag">
     <BookSearchSuggester
       list={props.list}
-      onSubmit={book => props.addElementToList(book, props.list.id)}
+      onSubmit={book => props.addElementToList(book, props.list._id)}
     />
     <DragableList
       list={props.list.list}
@@ -52,7 +52,7 @@ const ListBooks = props => (
       onUpdate={updatedList => {
         props.updateList({...props.list, list: updatedList});
       }}
-      onRemove={book => props.removeElementFromList(book, props.list.id)}
+      onRemove={book => props.removeElementFromList(book, props.list._id)}
     />
   </div>
 );
@@ -160,7 +160,7 @@ export class ListCreator extends React.Component {
     const currentList = this.props.currentList;
 
     this.props.updateList({
-      id: currentList.id,
+      _id: currentList._id,
       [selector]: !currentList[selector]
     });
 
@@ -168,17 +168,17 @@ export class ListCreator extends React.Component {
     // if public gets unchecked, uncheck both social and open
     if (selector === 'public' && currentList.public) {
       this.props.updateList({
-        id: currentList.id,
+        _id: currentList._id,
         social: false
       });
       this.props.updateList({
-        id: currentList.id,
+        _id: currentList._id,
         open: false
       });
       // if open or social gets checked, public is forced checked
     } else if (!currentList.social || !currentList.open) {
       this.props.updateList({
-        id: currentList.id,
+        _id: currentList._id,
         public: true
       });
     }
@@ -296,7 +296,7 @@ export class ListCreator extends React.Component {
                             : null
                         }
                         onFile={img => {
-                          this.props.addImage(currentList.id, img);
+                          this.props.addImage(currentList._id, img);
                         }}
                       >
                         {currentList.template === 'bookcase' ? (
@@ -400,9 +400,7 @@ export class ListCreator extends React.Component {
                   className="text-danger"
                   style={{cursor: 'pointer'}}
                   onClick={() =>
-                    this.props.confirmDeleteModal(
-                      this.props.currentList.id || this.props.currentList._id
-                    )
+                    this.props.confirmDeleteModal(this.props.currentList._id)
                   }
                 >
                   {isNew ? (
@@ -447,23 +445,23 @@ export const mapDispatchToProps = dispatch => ({
   addImage: (id, image) => dispatch({type: ADD_LIST_IMAGE, image, id}),
   updateList: data => dispatch(updateList(data)),
   storeList: async list => {
-    await dispatch(storeList(list.id));
+    await dispatch(storeList(list._id));
     dispatch({type: HISTORY_REPLACE, path: '/profile'});
   },
   exitList: path => dispatch({type: HISTORY_REPLACE, path: path}),
-  addElementToList: (book, id) => dispatch(addElementToList(book, id)),
-  removeElementFromList: (book, id) =>
-    dispatch(removeElementFromList(book, id)),
+  addElementToList: (book, _id) => dispatch(addElementToList(book, _id)),
+  removeElementFromList: (book, _id) =>
+    dispatch(removeElementFromList(book, _id)),
   loadLists: () => dispatch({type: LIST_LOAD_REQUEST}),
   createList: async () => {
-    const {id} = await saveList({});
-    dispatch(addList({id}));
+    const {_id} = await saveList({});
+    dispatch(addList({_id}));
     dispatch({
       type: HISTORY_REPLACE,
-      path: `/lister/${id}/rediger`
+      path: `/lister/${_id}/rediger`
     });
   },
-  confirmDeleteModal: id => {
+  confirmDeleteModal: _id => {
     dispatch({
       type: 'OPEN_MODAL',
       modal: 'confirm',
@@ -473,7 +471,7 @@ export const mapDispatchToProps = dispatch => ({
         confirmText: 'Slet liste',
         onConfirm: () =>
           dispatch(
-            removeList(id),
+            removeList(_id),
             dispatch({
               type: 'CLOSE_MODAL',
               modal: 'confirm'

--- a/src/client/components/list/ListItem.component.js
+++ b/src/client/components/list/ListItem.component.js
@@ -15,7 +15,7 @@ const Cover = ({pid, title, coverUrl, width, height}) => (
   />
 );
 
-const ListItem = ({list, title, id, image, type, hideIfEmpty = true}) => {
+const ListItem = ({list, title, _id, image, type, hideIfEmpty = true}) => {
   if (list.length === 0 && hideIfEmpty === true) {
     return null;
   }
@@ -23,7 +23,7 @@ const ListItem = ({list, title, id, image, type, hideIfEmpty = true}) => {
   let editButton = '';
   if (type === CUSTOM_LIST) {
     editButton = (
-      <Link href={`/lister/${id}/rediger`} className="small ml1 link-subtle">
+      <Link href={`/lister/${_id}/rediger`} className="small ml1 link-subtle">
         Redigér
       </Link>
     );
@@ -31,16 +31,16 @@ const ListItem = ({list, title, id, image, type, hideIfEmpty = true}) => {
 
   return (
     <div className="list-item tl mb1">
-      <Link href={`/lister/${id}`} className="list-image">
+      <Link href={`/lister/${_id}`} className="list-image">
         {image ? <img src={image} alt={title} /> : ''}
       </Link>
       <div className="ml2" style={{flexGrow: 1}}>
-        <Link href={`/lister/${id}`} className="link-dark">
+        <Link href={`/lister/${_id}`} className="link-dark">
           {title}
         </Link>
         {editButton}
       </div>
-      <Link href={`/lister/${id}`} className="ml2">
+      <Link href={`/lister/${_id}`} className="ml2">
         {list.slice(0, 5).map(el => {
           return (
             <span className="ml1" key={el.pid}>
@@ -48,7 +48,7 @@ const ListItem = ({list, title, id, image, type, hideIfEmpty = true}) => {
             </span>
           );
         })}
-        <Link href={`/lister/${id}`} className="ml1 link-subtle inline">
+        <Link href={`/lister/${_id}`} className="ml1 link-subtle inline">
           {list.length === 6
             ? '+ 1 bog mere'
             : list.length > 6

--- a/src/client/components/list/ListOverviewDropDown.container.js
+++ b/src/client/components/list/ListOverviewDropDown.container.js
@@ -17,7 +17,7 @@ import {HISTORY_PUSH} from '../../redux/middleware';
 import {getFollowedLists} from '../../redux/selectors';
 import {getListsForOwner} from '../../redux/list.reducer';
 const ListElement = props => {
-  const url = `/lister/${props.list.id}`;
+  const url = `/lister/${props.list._id}`;
   const renderListsCover = list => {
     return list.type === 'SYSTEM_LIST' ? (
       <img
@@ -29,7 +29,7 @@ const ListElement = props => {
     ) : (
       <div
         className="list-card-coverTemplate-small"
-        style={{background: toColor(list.id), height: '40px', width: '40px'}}
+        style={{background: toColor(list._id), height: '40px', width: '40px'}}
       >
         <div className="list-card-brick-small" />
         <div className="list-card-brick-small" />
@@ -104,12 +104,12 @@ class ListOverviewDropDown extends React.Component {
   sortLists(lists) {
     return lists.sort((a, b) => {
       let aDate =
-        !a._owner === this.props.userID && this.props.followReducer[a.id]
-          ? this.props.followReducer[a.id]._created
+        !a._owner === this.props.userID && this.props.followReducer[a._id]
+          ? this.props.followReducer[a._id]._created
           : a._created;
       let bDate =
-        !b._owner === this.props.userID && this.props.followReducer[a.id]
-          ? this.props.followReducer[b.id]._created
+        !b._owner === this.props.userID && this.props.followReducer[a._id]
+          ? this.props.followReducer[b._id]._created
           : b._created;
       aDate = a.type === 'SYSTEM_LIST' ? bDate + 1 : aDate;
       bDate = b.type === 'SYSTEM_LIST' ? aDate + 1 : bDate;
@@ -141,7 +141,7 @@ class ListOverviewDropDown extends React.Component {
             sortedLists.map(list => {
               return (
                 <ListElement
-                  key={list.id}
+                  key={list._id}
                   list={list}
                   profiles={this.props.profiles}
                   userID={this.props.userID ? this.props.userID : ''}

--- a/src/client/components/list/ListPage.container.js
+++ b/src/client/components/list/ListPage.container.js
@@ -34,7 +34,7 @@ export class ListPage extends React.Component {
       editButton = (
         <Link
           className="small link-subtle align-middle ml2"
-          href={`/lister/${list.id}/rediger`}
+          href={`/lister/${list._id}/rediger`}
         >
           Redigér liste
         </Link>

--- a/src/client/components/list/Lists.container.js
+++ b/src/client/components/list/Lists.container.js
@@ -18,8 +18,8 @@ export class Lists extends React.Component {
             <ListItem
               list={data.list}
               title={data.title}
-              id={data.id}
-              key={data.id}
+              _id={data._id}
+              key={data._id}
               type={data.type}
               image={data.image}
               hideIfEmpty={false}
@@ -31,8 +31,8 @@ export class Lists extends React.Component {
             <ListItem
               list={data.list}
               title={data.title}
-              id={data.id}
-              key={data.id}
+              _id={data._id}
+              key={data._id}
               type={data.type}
               image={data.image ? `/v1/image/${data.image}/50/50` : null}
               hideIfEmpty={false}

--- a/src/client/components/list/__tests__/AddToList.container.test.js
+++ b/src/client/components/list/__tests__/AddToList.container.test.js
@@ -16,9 +16,9 @@ const createTestElement = id => {
   };
 };
 
-const createList = id => {
+const createList = _id => {
   return {
-    id: id,
+    _id,
     title: 'some list',
     description: 'some description',
     list: [createTestElement(1), createTestElement(2), createTestElement(3)]

--- a/src/client/components/list/__tests__/ListCreate.test.js
+++ b/src/client/components/list/__tests__/ListCreate.test.js
@@ -29,7 +29,7 @@ const createTestElement = id => {
 describe('ListCreate', () => {
   test('list details is shown', () => {
     const currentList = {
-      id: 'current-list-id',
+      _id: 'current-list-id',
       title: 'some title',
       description: 'some description',
       public: true,
@@ -52,7 +52,7 @@ describe('ListCreate', () => {
 
   test('renders a list with one book', () => {
     const currentList = {
-      id: 'current-list-id',
+      _id: 'current-list-id',
       title: 'some title',
       description: 'some description',
       public: false,
@@ -75,7 +75,7 @@ describe('ListCreate', () => {
 
   test('renders a list with multiple books', () => {
     const currentList = {
-      id: 'current-list-id',
+      _id: 'current-list-id',
       title: 'some title',
       description: 'some description',
       public: false,

--- a/src/client/components/list/__tests__/ListItem.test.js
+++ b/src/client/components/list/__tests__/ListItem.test.js
@@ -12,7 +12,7 @@ describe('ListItem', () => {
         <ListItem
           list={[]}
           title={'some-title'}
-          id={'some-id'}
+          _id={'some-id'}
           key={'some-id'}
           type={'some-type'}
           image={null}

--- a/src/client/components/list/__tests__/Listpage.test.js
+++ b/src/client/components/list/__tests__/Listpage.test.js
@@ -16,9 +16,9 @@ const createTestElement = id => {
   };
 };
 
-const createList = id => {
+const createList = _id => {
   return {
-    id: id,
+    _id,
     owner: 'owner1',
     title: 'some list',
     description: 'some description',

--- a/src/client/components/list/__tests__/ListsContainer.test.js
+++ b/src/client/components/list/__tests__/ListsContainer.test.js
@@ -16,9 +16,9 @@ const createTestElement = id => {
   };
 };
 
-const createList = id => {
+const createList = _id => {
   return {
-    id: id,
+    _id,
     title: 'some list',
     description: 'some description',
     list: [createTestElement(1), createTestElement(2), createTestElement(3)]

--- a/src/client/components/list/__tests__/__snapshots__/AddToList.container.test.js.snap
+++ b/src/client/components/list/__tests__/__snapshots__/AddToList.container.test.js.snap
@@ -16,8 +16,8 @@ exports[`AddToList render when allowAdd is true 1`] = `
   <Connect(BookSearchSuggester)
     list={
       Object {
+        "_id": 1,
         "description": "some description",
-        "id": 1,
         "list": Array [
           Object {
             "book": Object {
@@ -73,8 +73,8 @@ exports[`AddToList show add and cancel buttons when selected book is not in list
   <Connect(BookSearchSuggester)
     list={
       Object {
+        "_id": 1,
         "description": "some description",
-        "id": 1,
         "list": Array [
           Object {
             "book": Object {
@@ -167,8 +167,8 @@ exports[`AddToList show error msg when selected books is already in list 1`] = `
   <Connect(BookSearchSuggester)
     list={
       Object {
+        "_id": 1,
         "description": "some description",
-        "id": 1,
         "list": Array [
           Object {
             "book": Object {

--- a/src/client/components/list/__tests__/__snapshots__/ListCreate.test.js.snap
+++ b/src/client/components/list/__tests__/__snapshots__/ListCreate.test.js.snap
@@ -155,8 +155,8 @@ exports[`ListCreate list details is shown 1`] = `
             <BookSearchSuggester
               list={
                 Object {
+                  "_id": "current-list-id",
                   "description": "some description",
-                  "id": "current-list-id",
                   "list": Array [],
                   "open": true,
                   "public": true,
@@ -427,8 +427,8 @@ exports[`ListCreate renders a list with multiple books 1`] = `
             <BookSearchSuggester
               list={
                 Object {
+                  "_id": "current-list-id",
                   "description": "some description",
-                  "id": "current-list-id",
                   "list": Array [
                     Object {
                       "book": Object {
@@ -903,8 +903,8 @@ exports[`ListCreate renders a list with one book 1`] = `
             <BookSearchSuggester
               list={
                 Object {
+                  "_id": "current-list-id",
                   "description": "some description",
-                  "id": "current-list-id",
                   "list": Array [
                     Object {
                       "book": Object {

--- a/src/client/components/list/__tests__/__snapshots__/Listpage.test.js.snap
+++ b/src/client/components/list/__tests__/__snapshots__/Listpage.test.js.snap
@@ -5,8 +5,8 @@ exports[`ListView List is rendered 1`] = `
   editButton=""
   list={
     Object {
+      "_id": "list1",
       "description": "some description",
-      "id": "list1",
       "list": Array [
         Object {
           "book": Object {
@@ -66,8 +66,8 @@ exports[`ListView edit button enabled, when isOwner true 1`] = `
   editButton=""
   list={
     Object {
+      "_id": "list1",
       "description": "some description",
-      "id": "list1",
       "list": Array [
         Object {
           "book": Object {

--- a/src/client/components/list/__tests__/__snapshots__/ListsContainer.test.js.snap
+++ b/src/client/components/list/__tests__/__snapshots__/ListsContainer.test.js.snap
@@ -33,8 +33,8 @@ exports[`Lists Container List is rendered 2`] = `
   lists={
     Array [
       Object {
+        "_id": 1,
         "description": "some description",
-        "id": 1,
         "list": Array [
           Object {
             "book": Object {
@@ -73,8 +73,8 @@ exports[`Lists Container List is rendered 2`] = `
         "title": "some list",
       },
       Object {
+        "_id": 2,
         "description": "some description",
-        "id": 2,
         "list": Array [
           Object {
             "book": Object {

--- a/src/client/components/list/templates/SimpleList.component.js
+++ b/src/client/components/list/templates/SimpleList.component.js
@@ -61,7 +61,7 @@ export class Item extends React.Component {
                 className="comment-edit-button btn btn-link link-subtle mr2"
                 onClick={() => this.setState({editing: !this.state.editing})}
               >
-                <i class="material-icons" style={{fontSize: '18px'}}>
+                <i className="material-icons" style={{fontSize: '18px'}}>
                   edit
                 </i>
               </button>
@@ -131,12 +131,12 @@ export class Item extends React.Component {
 }
 
 export class SimpleList extends React.Component {
-  toggleFollow(id, cat) {
+  toggleFollow(_id, cat) {
     if (this.props.isLoggedIn) {
-      if (this.props.follows[id]) {
-        this.props.unfollow(id);
+      if (this.props.follows[_id]) {
+        this.props.unfollow(_id);
       } else {
-        this.props.follow(id, cat);
+        this.props.follow(_id, cat);
       }
     } else {
       this.props.openModal(
@@ -177,9 +177,9 @@ export class SimpleList extends React.Component {
               txt="Følg"
               hoverTitle={'Følg ' + list.title}
               status={
-                this.props.follows[this.props.list.id] ? 'active' : 'passive'
+                this.props.follows[this.props.list._id] ? 'active' : 'passive'
               }
-              onClick={() => this.toggleFollow(list.id || list._id, 'list')}
+              onClick={() => this.toggleFollow(list._id, 'list')}
             />
 
             <SocialShareButton
@@ -187,7 +187,7 @@ export class SimpleList extends React.Component {
               facebook={true}
               href={
                 list.public
-                  ? 'https://content-first.demo.dbc.dk/lister/' + list.id
+                  ? 'https://content-first.demo.dbc.dk/lister/' + list._id
                   : null
               }
               hex={'#3b5998'}
@@ -197,7 +197,7 @@ export class SimpleList extends React.Component {
               status={!list.public ? 'passive' : 'active'}
               hoverTitle="Del på facebook"
               onClick={() => {
-                confirmShareModal(list.id);
+                confirmShareModal(list._id);
               }}
             />
           </div>
@@ -220,7 +220,7 @@ export class SimpleList extends React.Component {
               </div>
               <div className="col-9">
                 <p className="t-body">{list.description}</p>
-                {list.social ? <Comments id={list.id} /> : ''}
+                {list.social ? <Comments id={list._id} /> : ''}
               </div>
             </div>
           </div>
@@ -269,26 +269,26 @@ const mapStateToProps = (state, ownProps) => {
 };
 export const mapDispatchToProps = dispatch => ({
   removeElement: async (element, list) => {
-    await dispatch(removeElementFromList(element, list.id));
-    dispatch(storeList(list.id));
+    await dispatch(removeElementFromList(element, list._id));
+    dispatch(storeList(list._id));
   },
   updateElement: (element, list) => {
-    dispatch({type: UPDATE_LIST_ELEMENT, id: list.id, element});
+    dispatch({type: UPDATE_LIST_ELEMENT, _id: list._id, element});
   },
-  submit: list => dispatch(storeList(list.id)),
-  follow: (id, cat) =>
+  submit: list => dispatch(storeList(list._id)),
+  follow: (_id, cat) =>
     dispatch({
       type: FOLLOW,
-      id,
+      _id,
       cat
     }),
-  unfollow: id => {
+  unfollow: _id => {
     dispatch({
       type: UNFOLLOW,
-      id
+      _id
     });
   },
-  confirmShareModal: id => {
+  confirmShareModal: _id => {
     dispatch({
       type: 'OPEN_MODAL',
       modal: 'confirm',
@@ -300,7 +300,7 @@ export const mapDispatchToProps = dispatch => ({
         onConfirm: () => {
           dispatch(
             updateList({
-              id: id,
+              _id,
               public: true
             }),
             dispatch({
@@ -308,7 +308,7 @@ export const mapDispatchToProps = dispatch => ({
               modal: 'confirm'
             })
           );
-          dispatch(storeList(id));
+          dispatch(storeList(_id));
         },
         onCancel: () => {
           dispatch({

--- a/src/client/components/list/templates/__tests__/BookcaseTemplate.test.js
+++ b/src/client/components/list/templates/__tests__/BookcaseTemplate.test.js
@@ -29,7 +29,7 @@ const profile = {
 describe('BookcaseTemplate', () => {
   test('circle of list items is shown', () => {
     const list = {
-      id: 'current-list-id',
+      _id: 'current-list-id',
       title: 'some title',
       description: 'some description',
       public: true,

--- a/src/client/components/list/templates/__tests__/CircleTemplate.test.js
+++ b/src/client/components/list/templates/__tests__/CircleTemplate.test.js
@@ -34,7 +34,7 @@ const profile = {
 describe('CircleTemplate', () => {
   test('circle of list items is shown', () => {
     const list = {
-      id: 'current-list-id',
+      _id: 'current-list-id',
       title: 'some title',
       description: 'some description',
       public: true,

--- a/src/client/components/list/templates/__tests__/__snapshots__/BookcaseTemplate.test.js.snap
+++ b/src/client/components/list/templates/__tests__/__snapshots__/BookcaseTemplate.test.js.snap
@@ -7,9 +7,9 @@ exports[`BookcaseTemplate circle of list items is shown 1`] = `
   <BookcaseItem
     list={
       Object {
+        "_id": "current-list-id",
         "description": "some description",
         "descriptionImage": true,
-        "id": "current-list-id",
         "list": Array [
           Object {
             "book": Object {
@@ -118,9 +118,9 @@ exports[`BookcaseTemplate circle of list items is shown 1`] = `
     editButton={undefined}
     list={
       Object {
+        "_id": "current-list-id",
         "description": "some description",
         "descriptionImage": true,
-        "id": "current-list-id",
         "list": Array [
           Object {
             "book": Object {

--- a/src/client/components/list/templates/__tests__/__snapshots__/CircleTemplate.test.js.snap
+++ b/src/client/components/list/templates/__tests__/__snapshots__/CircleTemplate.test.js.snap
@@ -503,8 +503,8 @@ Array [
     editButton={undefined}
     list={
         Object {
+            "_id": "current-list-id",
             "description": "some description",
-            "id": "current-list-id",
             "list": Array [
               Object {
                 "book": Object {

--- a/src/client/components/work/WorkPreview.component.js
+++ b/src/client/components/work/WorkPreview.component.js
@@ -113,7 +113,7 @@ class WorkPreview extends React.Component {
                 collection.map(col => {
                   if (col.count === 1) {
                     return (
-                      <a href={col.url} target="_blank">
+                      <a href={col.url} target="_blank" key={col.url}>
                         <Button
                           type="quaternary"
                           size="medium"

--- a/src/client/redux/__tests__/__snapshots__/list.reducer.test.js.snap
+++ b/src/client/redux/__tests__/__snapshots__/list.reducer.test.js.snap
@@ -4,8 +4,8 @@ exports[`listReducer add element to list 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "list2",
     "description": "",
-    "id": "list2",
     "list": Array [
       Object {
         "book": Object {
@@ -31,8 +31,8 @@ exports[`listReducer add element to list twice - no duplicates allowed 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [
       Object {
         "book": Object {
@@ -72,8 +72,8 @@ exports[`listReducer add lists 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "a description 1",
-    "id": "some-id-1",
     "list": Array [],
     "owner": null,
     "title": "some list 1",
@@ -81,8 +81,8 @@ Array [
   },
   Object {
     "_created": "1234",
+    "_id": "some-id-2",
     "description": "a description 2",
-    "id": "some-id-2",
     "list": Array [],
     "owner": null,
     "title": "some list 2",
@@ -95,8 +95,8 @@ exports[`listReducer get lists by type 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [],
     "owner": null,
     "title": "some list 1",
@@ -104,8 +104,8 @@ Array [
   },
   Object {
     "_created": "1234",
+    "_id": "some-id-3",
     "description": "",
-    "id": "some-id-3",
     "list": Array [],
     "owner": null,
     "title": "some list 3",
@@ -118,8 +118,8 @@ exports[`listReducer get lists for owner 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [],
     "owner": "some-owner",
     "title": "some list 1",
@@ -127,8 +127,8 @@ Array [
   },
   Object {
     "_created": "1234",
+    "_id": "some-id-3",
     "description": "",
-    "id": "some-id-3",
     "list": Array [],
     "owner": "some-owner",
     "title": "some list 3",
@@ -143,8 +143,8 @@ exports[`listReducer insert element at specific pos in list 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [
       Object {
         "_id": 1,
@@ -190,11 +190,11 @@ exports[`listReducer remove element from list 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "deleted": Object {
       "123": true,
     },
     "description": "",
-    "id": "some-id-1",
     "list": Array [
       Object {
         "_id": "456",
@@ -229,9 +229,9 @@ exports[`listReducer remove list 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "deletingIsLoading": true,
     "description": "",
-    "id": "some-id-1",
     "list": Array [],
     "owner": null,
     "title": "some list 1",
@@ -239,8 +239,8 @@ Array [
   },
   Object {
     "_created": "1234",
+    "_id": "some-id-2",
     "description": "",
-    "id": "some-id-2",
     "list": Array [],
     "owner": null,
     "title": "some list 2",
@@ -253,8 +253,8 @@ exports[`listReducer toggle element in list 1`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [
       Object {
         "book": Object {
@@ -276,8 +276,8 @@ exports[`listReducer toggle element in list 2`] = `
 Array [
   Object {
     "_created": "1234",
+    "_id": "some-id-1",
     "description": "",
-    "id": "some-id-1",
     "list": Array [],
     "owner": null,
     "title": "some list 1",

--- a/src/client/redux/__tests__/list.reducer.test.js
+++ b/src/client/redux/__tests__/list.reducer.test.js
@@ -45,7 +45,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'list1',
+        _id: 'list1',
         _created: '1234'
       })
     );
@@ -82,7 +82,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         description: 'a description 1',
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -91,7 +91,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 2',
         description: 'a description 2',
-        id: 'some-id-2',
+        _id: 'some-id-2',
         _created: '1234'
       })
     );
@@ -105,7 +105,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -114,7 +114,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 2',
         type: CUSTOM_LIST,
-        id: 'some-id-2',
+        _id: 'some-id-2',
         _created: '1234'
       })
     );
@@ -130,7 +130,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -139,7 +139,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 2',
         type: SYSTEM_LIST,
-        id: 'some-id-2',
+        _id: 'some-id-2',
         _created: '1234'
       })
     );
@@ -148,7 +148,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 3',
         type: CUSTOM_LIST,
-        id: 'some-id-3',
+        _id: 'some-id-3',
         _created: '1234'
       })
     );
@@ -163,7 +163,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         owner: 'some-owner',
         _created: '1234'
       })
@@ -173,7 +173,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 2',
         type: SYSTEM_LIST,
-        id: 'some-id-2',
+        _id: 'some-id-2',
         owner: 'some-owner-2',
         _created: '1234'
       })
@@ -183,7 +183,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 3',
         type: CUSTOM_LIST,
-        id: 'some-id-3',
+        _id: 'some-id-3',
         owner: 'some-owner',
         _created: '1234'
       })
@@ -200,7 +200,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'list2',
+        _id: 'list2',
         _created: '1234'
       })
     );
@@ -218,7 +218,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -263,7 +263,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -294,7 +294,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );
@@ -322,7 +322,7 @@ describe('listReducer', () => {
       addList({
         title: 'some list 1',
         type: CUSTOM_LIST,
-        id: 'some-id-1',
+        _id: 'some-id-1',
         _created: '1234'
       })
     );

--- a/src/client/redux/interaction.middleware.js
+++ b/src/client/redux/interaction.middleware.js
@@ -114,7 +114,7 @@ export const interactionMiddleware = store => next => action => {
 
     case LIST_TOGGLE_ELEMENT: {
       const notChecked = isNotChecked(
-        store.getState().listReducer.lists[action.id].list,
+        store.getState().listReducer.lists[action._id].list,
         action.element.book.pid
       );
       if (notChecked) {

--- a/src/client/redux/list.reducer.js
+++ b/src/client/redux/list.reducer.js
@@ -37,59 +37,59 @@ const listReducer = (state = defaultState, action) => {
   switch (action.type) {
     case ADD_LIST: {
       const {list} = action;
-      if (!list.id) {
-        throw new Error('Cant add list when list.data.id is not set');
+      if (!list._id) {
+        throw new Error('Cant add list when list.data._id is not set');
       }
       return Object.assign({}, state, {
-        lists: {...state.lists, [list.id]: list}
+        lists: {...state.lists, [list._id]: list}
       });
     }
     case REMOVE_LIST: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
 
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         deletingIsLoading: true
       };
 
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case REMOVE_LIST_SUCCESS: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
 
       const lists = {...state.lists};
 
-      delete lists[action.id];
+      delete lists[action._id];
 
       return Object.assign({}, state, {lists});
     }
     case REMOVE_LIST_ERROR: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
 
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         error: action.error,
         deletingIsLoading: false
       };
 
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case ADD_ELEMENT_TO_LIST: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
-      if (!state.lists[action.id]) {
-        throw new Error(`Could not find list with id ${action.id}`);
+      if (!state.lists[action._id]) {
+        throw new Error(`Could not find list with _id ${action._id}`);
       }
       if (!action.element) {
         throw new Error("'element' is missing from action");
@@ -102,7 +102,7 @@ const listReducer = (state = defaultState, action) => {
       });
 
       const list = {
-        ...state.lists[action.id]
+        ...state.lists[action._id]
       };
 
       if (
@@ -117,16 +117,16 @@ const listReducer = (state = defaultState, action) => {
         list.list = [...list.list, action.element];
       }
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list},
+        lists: {...state.lists, [action._id]: list},
         changeMap
       });
     }
     case REMOVE_ELEMENT_FROM_LIST: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
-      if (!state.lists[action.id]) {
-        throw new Error(`Could not find list with id ${action.id}`);
+      if (!state.lists[action._id]) {
+        throw new Error(`Could not find list with _id ${action._id}`);
       }
       if (!action.element) {
         throw new Error("'element' is missing from action");
@@ -135,7 +135,7 @@ const listReducer = (state = defaultState, action) => {
         [action.element.book.pid]: {}
       });
       const list = {
-        ...state.lists[action.id]
+        ...state.lists[action._id]
       };
       list.deleted = list.deleted || {};
       list.deleted[action.element._id] = true;
@@ -145,16 +145,16 @@ const listReducer = (state = defaultState, action) => {
         element => element.pid !== action.element.book.pid
       );
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list},
+        lists: {...state.lists, [action._id]: list},
         changeMap
       });
     }
     case LIST_INSERT_ELEMENT: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
-      if (!state.lists[action.id]) {
-        throw new Error(`Could not find list with id ${action.id}`);
+      if (!state.lists[action._id]) {
+        throw new Error(`Could not find list with _id ${action._id}`);
       }
       if (!action.element) {
         throw new Error("'element' is missing from action");
@@ -166,7 +166,7 @@ const listReducer = (state = defaultState, action) => {
         [action.element.book.pid]: {}
       });
       const list = {
-        ...state.lists[action.id]
+        ...state.lists[action._id]
       };
       const listElements = [...list.list];
       listElements.splice(
@@ -179,16 +179,16 @@ const listReducer = (state = defaultState, action) => {
           !(element.book.pid === action.element.book.pid && idx !== action.pos)
       );
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list},
+        lists: {...state.lists, [action._id]: list},
         changeMap
       });
     }
     case LIST_TOGGLE_ELEMENT: {
-      if (!action.id) {
+      if (!action._id) {
         throw new Error("'id' is missing from action");
       }
-      if (!state.lists[action.id]) {
-        throw new Error(`Could not find list with id ${action.id}`);
+      if (!state.lists[action._id]) {
+        throw new Error(`Could not find list with _id ${action._id}`);
       }
       if (!action.element) {
         throw new Error("'element' is missing from action");
@@ -197,7 +197,7 @@ const listReducer = (state = defaultState, action) => {
         [action.element.book.pid]: {}
       });
       const list = {
-        ...state.lists[action.id]
+        ...state.lists[action._id]
       };
       const removed = list.list.filter(e => e.pid !== action.element.book.pid);
       if (removed.length < list.list.length) {
@@ -207,7 +207,7 @@ const listReducer = (state = defaultState, action) => {
         list.list = [...list.list, action.element];
       }
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list},
+        lists: {...state.lists, [action._id]: list},
         changeMap
       });
     }
@@ -215,12 +215,12 @@ const listReducer = (state = defaultState, action) => {
       if (!action.data) {
         throw new Error("'data' is missing from action");
       }
-      if (!state.lists[action.data.id]) {
-        throw new Error(`Could not find list with id ${action.data.id}`);
+      if (!state.lists[action.data._id]) {
+        throw new Error(`Could not find list with _id ${action.data._id}`);
       }
-      const list = {...state.lists[action.data.id], ...action.data};
+      const list = {...state.lists[action.data._id], ...action.data};
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.data.id]: list}
+        lists: {...state.lists, [action.data._id]: list}
       });
     }
     case LIST_LOAD_RESPONSE: {
@@ -240,7 +240,7 @@ const listReducer = (state = defaultState, action) => {
             };
           }
         });
-        return (listMap[l.id] = l);
+        return (listMap[l._id] = l);
       });
 
       return Object.assign({}, state, {
@@ -251,13 +251,13 @@ const listReducer = (state = defaultState, action) => {
     case ADD_LIST_IMAGE: {
       validateId(state, action);
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         imageIsLoading: true,
         image: null,
         imageError: null
       };
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case UPDATE_LIST_ELEMENT: {
@@ -266,7 +266,7 @@ const listReducer = (state = defaultState, action) => {
         throw new Error("'element' is missing from action");
       }
       const list = {
-        ...state.lists[action.id]
+        ...state.lists[action._id]
       };
       list.list = list.list.map(element => {
         if (action.element._id === element._id) {
@@ -276,43 +276,43 @@ const listReducer = (state = defaultState, action) => {
       });
 
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case ADD_LIST_IMAGE_SUCCESS: {
       validateId(state, action);
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         imageIsLoading: false,
-        image: action.image.id,
+        image: action.image._id,
         imageError: null
       };
 
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case ADD_LIST_IMAGE_ERROR: {
       validateId(state, action);
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         imageIsLoading: true,
         image: null,
         imageError: action.error
       };
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list}
+        lists: {...state.lists, [action._id]: list}
       });
     }
     case STORE_LIST: {
       const list = {
-        ...state.lists[action.id],
+        ...state.lists[action._id],
         pending: []
       };
       list._modified = null;
       return Object.assign({}, state, {
-        lists: {...state.lists, [action.id]: list},
-        latestUsedId: action.id
+        lists: {...state.lists, [action._id]: list},
+        latestUsedId: action._id
       });
     }
     case ON_USERLISTS_EXPAND:
@@ -331,14 +331,14 @@ export const addList = ({
   title = '',
   description = '',
   list = [],
-  id = null,
+  _id = null,
   owner = null,
   _created = Date.now()
 }) => {
   return {
     type: ADD_LIST,
     list: {
-      id,
+      _id,
       type,
       title,
       description,
@@ -354,45 +354,45 @@ export const updateList = data => {
     data
   };
 };
-export const removeList = id => {
+export const removeList = _id => {
   return {
     type: REMOVE_LIST,
-    id
+    _id
   };
 };
-export const addElementToList = (element, id) => {
+export const addElementToList = (element, _id) => {
   return {
     type: ADD_ELEMENT_TO_LIST,
     element,
-    id
+    _id
   };
 };
-export const removeElementFromList = (element, id) => {
+export const removeElementFromList = (element, _id) => {
   return {
     type: REMOVE_ELEMENT_FROM_LIST,
     element,
-    id
+    _id
   };
 };
-export const toggleElementInList = (element, id) => {
+export const toggleElementInList = (element, _id) => {
   return {
     type: LIST_TOGGLE_ELEMENT,
     element,
-    id
+    _id
   };
 };
-export const insertElement = (element, pos, id) => {
+export const insertElement = (element, pos, _id) => {
   return {
     type: LIST_INSERT_ELEMENT,
     element,
     pos,
-    id
+    _id
   };
 };
-export const storeList = id => {
+export const storeList = _id => {
   return {
     type: STORE_LIST,
-    id
+    _id
   };
 };
 
@@ -411,6 +411,9 @@ export const getLists = (state, {type, sort} = {}) => {
   const lists = Object.values(listState.lists)
     .filter(l => {
       if (type && l.type !== type) {
+        return false;
+      }
+      if (!l.title) {
         return false;
       }
       return true;
@@ -455,11 +458,11 @@ export const getPublicLists = state => {
     });
 };
 
-export const getListById = (state, id) => {
+export const getListById = (state, _id) => {
   const listState = state.listReducer;
   const booksState = state.booksReducer;
 
-  let list = listState.lists[id];
+  let list = listState.lists[_id];
   if (!list) {
     return;
   }
@@ -484,11 +487,11 @@ export const getListById = (state, id) => {
 };
 
 const validateId = (state, action) => {
-  if (!action.id) {
-    throw new Error("'id' is not defined");
+  if (!action._id) {
+    throw new Error("'_id' is not defined");
   }
-  if (!state.lists[action.id]) {
-    throw new Error(`Could not find list with id ${action.id}`);
+  if (!state.lists[action._id]) {
+    throw new Error(`Could not find list with _id ${action._id}`);
   }
 };
 

--- a/src/client/redux/middleware.js
+++ b/src/client/redux/middleware.js
@@ -221,22 +221,22 @@ export const listMiddleware = store => next => async action => {
   switch (action.type) {
     case STORE_LIST: {
       const {openplatformId} = store.getState().userReducer;
-      const list = getListById(store.getState(), action.id);
+      const list = getListById(store.getState(), action._id);
       if (!list) {
-        throw new Error(`list with id ${action.id} not found`);
+        throw new Error(`list with _id ${action._id} not found`);
       }
       if (store.getState().userReducer.isLoggedIn) {
         const updatedList = await saveList(list, openplatformId);
         store.dispatch({
           type: ADD_LIST,
-          id: updatedList.id,
+          _id: updatedList._id,
           list: updatedList
         });
       }
       return next(action);
     }
     case ADD_LIST: {
-      if (!action.list.id) {
+      if (!action.list._id) {
         action.list = await saveList(action.list, null);
       }
       if (!action.list.owner) {
@@ -245,14 +245,14 @@ export const listMiddleware = store => next => async action => {
       return next(action);
     }
     case REMOVE_LIST: {
-      const id = action.id;
+      const _id = action._id;
 
       (async () => {
         try {
-          await deleteObject({_id: id});
-          store.dispatch({type: REMOVE_LIST_SUCCESS, id: id});
+          await deleteObject({_id});
+          store.dispatch({type: REMOVE_LIST_SUCCESS, _id});
         } catch (error) {
-          store.dispatch({type: REMOVE_LIST_ERROR, error, id: id});
+          store.dispatch({type: REMOVE_LIST_ERROR, error, _id});
         }
       })();
       return next(action);
@@ -295,9 +295,13 @@ export const listMiddleware = store => next => async action => {
       return (async () => {
         try {
           const image = await addImage(action.image);
-          store.dispatch({type: ADD_LIST_IMAGE_SUCCESS, image, id: action.id});
+          store.dispatch({
+            type: ADD_LIST_IMAGE_SUCCESS,
+            image,
+            _id: action._id
+          });
         } catch (error) {
-          store.dispatch({type: ADD_LIST_IMAGE_ERROR, error, id: action.id});
+          store.dispatch({type: ADD_LIST_IMAGE_ERROR, error, _id: action._id});
         }
       })();
     default:
@@ -322,10 +326,10 @@ const logged = {
     pid: element.book.pid,
     origin
   }),
-  LIST_TOGGLE_ELEMENT: ({type, element, id}) => ({
+  LIST_TOGGLE_ELEMENT: ({type, element, _id}) => ({
     type,
     pid: element.book.pid,
-    id
+    _id
   }),
   ORDER: ({type, book}) => ({type, pid: book.pid}),
   ORDER_SUCCESS: o => o,

--- a/src/client/utils/requestLists.js
+++ b/src/client/utils/requestLists.js
@@ -18,7 +18,6 @@ export const saveList = async (list, loggedInUserId) => {
 
   if (!list._id && list.list.length > 0) {
     Object.assign(list, (await request.post('/v1/object').send({})).body.data);
-    list.id = list._key || list._id;
   }
 
   // update all elements owned by logged in user
@@ -34,7 +33,7 @@ export const saveList = async (list, loggedInUserId) => {
           _type: 'list-entry',
           book: null,
           pid: book.pid,
-          _key: list.id,
+          _key: list._id,
           _rev: null,
           _public: list._public
         });
@@ -79,8 +78,6 @@ export const saveList = async (list, loggedInUserId) => {
     );
     Object.assign(list, result.body.data);
   }
-  // old-endpoint compat, refactor to just _id later
-  list.id = list._key || list._id;
 
   return list;
 };
@@ -96,7 +93,6 @@ export const loadRecentPublic = async ({store}) => {
 };
 
 async function enrichList({list}) {
-  list.id = list.id || list._id;
   list.owner = list._owner;
 
   // Load list elements
@@ -115,7 +111,7 @@ async function enrichList({list}) {
   // Add elements for open lists
   if (list.open) {
     let othersListEntries = (await request.get(
-      `/v1/object/find?type=list-entry&key=${list.id}&limit=100000`
+      `/v1/object/find?type=list-entry&key=${list._id}&limit=100000`
     )).body.data;
 
     list.deleted = list.deleted || {};


### PR DESCRIPTION
#263 

Fejlen opstod fordi på nogle ældre lister var id og _id ikke ens - og det var lidt forskelligt, hvilken property der blev brugt rundt omkring i koden. Nu bruges kun _id, så forhåbentligt rettes fejlen.