### PR TITLE
adjustet title backfill limit

### DIFF
--- a/src/client/components/filter/TagsSuggester.component.js
+++ b/src/client/components/filter/TagsSuggester.component.js
@@ -202,7 +202,9 @@ class TagsSuggester extends React.Component {
       titleSuggestions = {
         suggestions: this.state.titleSuggestions.suggestions.slice(
           0,
-          6 - tagsSuggestions.suggestions.length
+          10 -
+            (tagsSuggestions.suggestions.length +
+              authorSuggestions.suggestions.length)
         ),
         title: titleSuggestions.title
       };


### PR DESCRIPTION
Backfill limit er nu ændret fra max 6 til 10 - så max resultatet følger de øvrige max resultater i suggesteren. 