### PR TITLE
600 filtrering på længde

### DIFF
--- a/src/client/components/filter/FilterPage.container.js
+++ b/src/client/components/filter/FilterPage.container.js
@@ -10,8 +10,9 @@ import {
   ON_EXPAND_FILTERS_TOGGLE
 } from '../../redux/filter.reducer';
 import {HISTORY_REPLACE, HISTORY_PUSH} from '../../redux/middleware';
-import {RECOMMEND_REQUEST, getRecommendedPids} from '../../redux/recommend';
+import {RECOMMEND_REQUEST} from '../../redux/recommend';
 import {
+  getRecommendedBooks,
   getTagsFromUrl,
   getCreatorsFromUrl,
   getTitlesFromUrl,
@@ -71,7 +72,7 @@ class FilterPage extends React.Component {
   render() {
     const resultCount = this.props.recommendedPids.pids.length;
     const resultCountPrefixText =
-      resultCount === 100 ? 'Mere end ' + resultCount : resultCount;
+      resultCount === 300 ? 'Mere end ' + resultCount : resultCount;
     const resultCountPostFix = resultCount === 1 ? 'bog' : 'bøger';
     const noResultsMessage =
       'Vi fandt desværre ingen bøger som matchede din søgning';
@@ -150,9 +151,7 @@ const mapStateToProps = state => {
       ? {pids: state.searchReducer.results.map(work => work.pid)}
       : null;
 
-  const recommendedPids = getRecommendedPids(state.recommendReducer, {
-    tags: plainSelectedTagIds
-  });
+  const recommendedPids = getRecommendedBooks(state, plainSelectedTagIds, 300);
 
   return {
     recommendedPids: results || recommendedPids,
@@ -180,7 +179,7 @@ export const mapDispatchToProps = dispatch => ({
     dispatch({
       type: RECOMMEND_REQUEST,
       tags,
-      max: 100 // we ask for many recommendations, since client side filtering may reduce the actual result significantly
+      max: 300 // we ask for many recommendations, since client side filtering may reduce the actual result significantly
     })
 });
 export default connect(

--- a/src/client/components/filter/SearchBar.component.js
+++ b/src/client/components/filter/SearchBar.component.js
@@ -5,9 +5,9 @@ import ToastMessage from '../base/ToastMessage';
 import SelectedFilters from './SelectedFilters.component';
 import {filtersMapAll} from '../../redux/filter.reducer';
 import {HISTORY_REPLACE} from '../../redux/middleware';
-import {getRecommendedPids} from '../../redux/recommend';
 import {BOOKS_REQUEST} from '../../redux/books.reducer';
 import {
+  getRecommendedBooks,
   getTagsFromUrl,
   getCreatorsFromUrl,
   getTitlesFromUrl,
@@ -283,9 +283,7 @@ const mapStateToProps = state => {
   );
 
   return {
-    recommendedPids: getRecommendedPids(state.recommendReducer, {
-      tags: plainSelectedTagIds
-    }),
+    recommendedPids: getRecommendedBooks(state, plainSelectedTagIds, 300),
     filterCards,
     router: state.routerReducer,
     selectedTagIds: mergedSelectedTags,

--- a/src/client/components/filter/templates/CardRange.component.js
+++ b/src/client/components/filter/templates/CardRange.component.js
@@ -82,8 +82,12 @@ class CardRange extends React.Component {
     selectedTagIds.forEach((id, idx) => {
       if (id instanceof Array) {
         if (range.includes(id[0]) && range.includes(id[1])) {
-          tags[idx] = filterId[0] + ',' + filterId[1];
-          allowAdd = false;
+          if (!widest) {
+            tags[idx] = filterId[0] + ',' + filterId[1];
+            allowAdd = false;
+          } else {
+            tags.splice(idx, 1);
+          }
         }
       }
     });

--- a/src/client/redux/recommend.js
+++ b/src/client/redux/recommend.js
@@ -2,6 +2,7 @@ import librarianRecommends from '../../data/librarian-recommends.json';
 import request from 'superagent';
 import {uniq} from 'lodash';
 import {filtersMapAll} from './filter.reducer';
+import {BOOKS_REQUEST} from './books.reducer';
 
 const librarianRecommendsMap = librarianRecommends.reduce((map, pid) => {
   map[pid] = true;
@@ -163,6 +164,10 @@ export const recommendMiddleware = store => next => action => {
             store.dispatch({
               ...action,
               type: RECOMMEND_RESPONSE,
+              pids
+            });
+            store.dispatch({
+              type: BOOKS_REQUEST,
               pids
             });
           } catch (error) {

--- a/src/client/redux/selectors.js
+++ b/src/client/redux/selectors.js
@@ -7,28 +7,28 @@ import {getRecommendedPids, applyClientSideFilters} from './recommend';
 import {filtersMapAll} from './filter.reducer';
 import {getListById} from './list.reducer';
 
-export const getRecommendedBooks = (state, tags, max) => {
+export const getRecommendedBooks = (state, tags, max = 100) => {
   const {recommendReducer, booksReducer} = state;
-  const result = {tags};
-  const r = getRecommendedPids(recommendReducer, {tags});
-  const books = getBooks(booksReducer, r.pids);
-  let booksAreLoading = false;
+  const recommendedPids = getRecommendedPids(recommendReducer, {tags});
+  const books = getBooks(booksReducer, recommendedPids.pids);
 
+  let booksAreLoading = false;
   books.forEach(b => {
     if (b.isLoading) {
       booksAreLoading = true;
     }
   });
 
-  result.isLoading = r.isLoading || booksAreLoading || false;
-  result.books = result.isLoading ? [] : applyClientSideFilters(books, tags);
-  result.books = result.books.slice(0, max);
+  const result = {};
+  result.isLoading = booksAreLoading;
+  result.pids = booksAreLoading ? [] : applyClientSideFilters(books, tags);
+  result.pids = result.pids.map(b => b.book.pid).slice(0, max);
+
   return result;
 };
 
 export const getFollowedLists = state => {
   const follows = state.followReducer;
-
   const result = Object.values(follows)
     .filter(follow => follow.cat === 'list')
     .map(follow => getListById(state, follow.id))


### PR DESCRIPTION
løser issue: #600 

Der kunne ikke længere filtreres på længde clientside, da "bog" objektet nu kun består af en liste med pid'er. 

Funktionen getRecommendedPids på filtersiden er nu blevet erstattet med getRecommendedBooks, som henter bøgerne for piderne og derefter returnerer piderne igen. 