### PR TITLE
601 length in suggester

### DIFF
--- a/src/client/components/filter/SearchBar.component.js
+++ b/src/client/components/filter/SearchBar.component.js
@@ -54,6 +54,8 @@ class SearchBar extends React.Component {
 
       selectedTagIds = selectedTagIdsTrimmed;
 
+      console.log('filterId', filterId);
+
       const filter = filtersMapAll[filterId] || filtersMapAll[filterId[0]];
       const parent = filtersMapAll[filter.id].parents[0];
       const range = (filterCards[parent] && filterCards[parent].range) || false;

--- a/src/client/components/filter/SearchBar.component.js
+++ b/src/client/components/filter/SearchBar.component.js
@@ -54,8 +54,6 @@ class SearchBar extends React.Component {
 
       selectedTagIds = selectedTagIdsTrimmed;
 
-      console.log('filterId', filterId);
-
       const filter = filtersMapAll[filterId] || filtersMapAll[filterId[0]];
       const parent = filtersMapAll[filter.id].parents[0];
       const range = (filterCards[parent] && filterCards[parent].range) || false;

--- a/src/client/components/filter/SelectedFilters.component.js
+++ b/src/client/components/filter/SelectedFilters.component.js
@@ -46,6 +46,7 @@ class SelectedFilters extends React.Component {
         >
           <TagsSuggester
             selectedFilters={this.props.selectedFilters}
+            filters={this.props.filters}
             value={this.props.query}
             onKeyDown={this.props.onKeyDown}
             onFocus={this.props.onFocus}

--- a/src/client/components/filter/TagsSuggester.component.js
+++ b/src/client/components/filter/TagsSuggester.component.js
@@ -70,9 +70,28 @@ class TagsSuggester extends React.Component {
       tagsSuggestions: {title: 'Tags', suggestions: []},
       authorSuggestions: {title: 'Forfatterer', suggestions: []},
       titleSuggestions: {title: 'Bøger', suggestions: []},
+      clientSuggestions: {title: 'Tags', suggestions: []},
       suggestions: [],
       inputVisibel: true
     };
+  }
+
+  clientsideFilters({value}) {
+    const filters = this.props.filters;
+    const length = filters.Længde.filter(l =>
+      l.title.toLowerCase().includes(value)
+    ).map(l => {
+      return {
+        id: l.id,
+        title: l.title,
+        text: l.title,
+        parents: ['', 'Længde']
+      };
+    });
+
+    this.setState({
+      clientSuggestions: {title: 'Tags', suggestions: length}
+    });
   }
 
   async onTagsSuggestionsFetchRequested({value}) {
@@ -169,7 +188,18 @@ class TagsSuggester extends React.Component {
   }
 
   renderSuggestions() {
-    let {tagsSuggestions, authorSuggestions, titleSuggestions} = this.state;
+    let {
+      tagsSuggestions,
+      clientSuggestions,
+      authorSuggestions,
+      titleSuggestions
+    } = this.state;
+
+    // Add client tags to suggestion tags
+    tagsSuggestions.suggestions = [
+      ...tagsSuggestions.suggestions,
+      ...clientSuggestions.suggestions
+    ];
 
     // Fill suggestions with authors (Maximum 2)
     authorSuggestions = {
@@ -276,6 +306,7 @@ class TagsSuggester extends React.Component {
             onSuggestionsFetchRequested={async e => {
               await this.onTagsSuggestionsFetchRequested(e);
               await this.onAuthorTitleSuggestionsFetchRequested(e);
+              this.clientsideFilters(e);
               this.setState({suggestions: this.renderSuggestions()});
             }}
             onSuggestionsClearRequested={() => {

--- a/src/client/components/list/ListOverviewDropDown.container.js
+++ b/src/client/components/list/ListOverviewDropDown.container.js
@@ -67,7 +67,7 @@ const UserListsContent = props => {
         props.expanded ? '' : ' slide-out'
       }`}
     >
-       <i
+      <i
         onClick={props.onClose}
         className="material-icons top-bar-dropdown-list--close-btn"
       >


### PR DESCRIPTION
løser issue: #601 

klientfiltrenes sortering med de øvrige tags vil i nogen tilfælde opleves lidt forkerte, da de 2 tagobjekter bare er sat sammen. 

Der oprettes et nyt issue på bedre sortering af søgeresultaterne i suggesteren, for både tags, klient tags, forfatterer og titler. 