### PR TITLE
647 - changed text in login dialog

### DIFF
--- a/src/client/components/general/AddToListButton.component.js
+++ b/src/client/components/general/AddToListButton.component.js
@@ -95,8 +95,8 @@ export class AddToListButton extends React.Component {
           onClick={() => {
             this.props.openModal(
               {
-                title: 'BESTIL',
-                reason: 'Du skal logge ind for at bestille bøger'
+                title: 'LÆG I LISTE',
+                reason: 'Du skal logge ind for at lægge bøger i en liste.'
               },
               'login'
             );


### PR DESCRIPTION
Lige en lille mangel fra issue #647, hvor teksten i modalvinduet som skulle åbne var forkert. Det er nu rettet her. 