### PR TITLE
validate checksum of taxonomy before injecting data

### DIFF
--- a/src/server/external-server.js
+++ b/src/server/external-server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+const taxonomy = require('../data/exportTaxonomy.json');
 const config = require('server/config');
 const constants = require('server/constants')();
 const logger = require('server/logger');
@@ -71,6 +73,10 @@ external.get('/howru', async (req, res) => {
     address: req.ip,
     config: configWithoutSecrets
   });
+  status.taxonomySHA256 = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(taxonomy))
+    .digest('hex');
   if (!status.ok) {
     res.status(503);
   }

--- a/src/server/external-server.js
+++ b/src/server/external-server.js
@@ -72,10 +72,14 @@ external.get('/howru', async (req, res) => {
     address: req.ip,
     config: configWithoutSecrets
   });
-  status.taxonomySHA256 = crypto
-    .createHash('sha256')
-    .update(JSON.stringify(require('../data/exportTaxonomy.json')))
-    .digest('hex');
+  try {
+    status.taxonomySHA256 = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(require('../data/exportTaxonomy.json')))
+      .digest('hex');
+  } catch (e) {
+    status.taxonomySHA256 = '';
+  }
   if (!status.ok) {
     res.status(503);
   }

--- a/src/server/external-server.js
+++ b/src/server/external-server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const crypto = require('crypto');
-const taxonomy = require('../data/exportTaxonomy.json');
 const config = require('server/config');
 const constants = require('server/constants')();
 const logger = require('server/logger');
@@ -75,7 +74,7 @@ external.get('/howru', async (req, res) => {
   });
   status.taxonomySHA256 = crypto
     .createHash('sha256')
-    .update(JSON.stringify(taxonomy))
+    .update(JSON.stringify(require('../data/exportTaxonomy.json')))
     .digest('hex');
   if (!status.ok) {
     res.status(503);


### PR DESCRIPTION
related to #757 

howru giver en checksum af taksonomi tilbage.
På inject-tidspunktet bruges checksum til at finde ud af om metakompas og content-first er i sync