### PR TITLE
836 dont hide save button slf

### DIFF
--- a/src/client/components/comments/CommentInput.component.js
+++ b/src/client/components/comments/CommentInput.component.js
@@ -48,6 +48,9 @@ export default class CommentInput extends React.Component {
             }
             this.setState({focus: true});
           }}
+          onBlur={() => {
+            this.setState({focus: false});
+          }}
         >
           <Textarea
             autoFocus={this.props.autoFocus}
@@ -57,9 +60,6 @@ export default class CommentInput extends React.Component {
             name="list-description"
             placeholder={this.props.placeholder || 'Skriv kommentar'}
             onChange={e => this.props.onChange(e.target.value)}
-            onBlur={() => {
-              this.setState({focus: false});
-            }}
             value={this.props.value}
           />
           {this.props.error && this.props.error.comment === this.props.value ? (
@@ -70,8 +70,8 @@ export default class CommentInput extends React.Component {
           <div
             className="tr"
             style={{
-              height: this.state.focus || this.state.value ? '50px' : '0px',
-              opacity: this.state.focus || this.state.value ? 1 : 0,
+              height: this.state.focus || this.props.value ? '50px' : '0px',
+              opacity: this.state.focus || this.props.value ? 1 : 0,
               overflow: 'hidden',
               transition: 'all 200ms'
             }}

--- a/src/client/components/comments/__tests__/__snapshots__/CommentContainer.test.js.snap
+++ b/src/client/components/comments/__tests__/__snapshots__/CommentContainer.test.js.snap
@@ -84,6 +84,7 @@ exports[`CommentContainer Component fetches comments on mount 1`] = `
       </div>
       <div
         className="form-group "
+        onBlur={[Function]}
         onFocus={[Function]}
         style={
           Object {
@@ -96,7 +97,6 @@ exports[`CommentContainer Component fetches comments on mount 1`] = `
           className="form-control mb1 comment-textarea"
           disabled={undefined}
           name="list-description"
-          onBlur={[Function]}
           onChange={[Function]}
           placeholder="Skriv kommentar"
           value=""
@@ -267,6 +267,7 @@ exports[`CommentContainer Component renders a list of comments 1`] = `
       </div>
       <div
         className="form-group "
+        onBlur={[Function]}
         onFocus={[Function]}
         style={
           Object {
@@ -279,7 +280,6 @@ exports[`CommentContainer Component renders a list of comments 1`] = `
           className="form-control mb1 comment-textarea"
           disabled={undefined}
           name="list-description"
-          onBlur={[Function]}
           onChange={[Function]}
           placeholder="Skriv kommentar"
           value=""
@@ -641,6 +641,7 @@ exports[`CommentContainer Component renders all comments 1`] = `
           </ProfileImage>
           <div
             className="form-group "
+            onBlur={[Function]}
             onFocus={[Function]}
             style={
               Object {
@@ -651,7 +652,6 @@ exports[`CommentContainer Component renders all comments 1`] = `
             <textarea
               className="form-control mb1 comment-textarea"
               name="list-description"
-              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Skriv kommentar"
               value=""
@@ -821,6 +821,7 @@ exports[`CommentContainer Component renders comment with links and emojis 1`] = 
       </div>
       <div
         className="form-group "
+        onBlur={[Function]}
         onFocus={[Function]}
         style={
           Object {
@@ -833,7 +834,6 @@ exports[`CommentContainer Component renders comment with links and emojis 1`] = 
           className="form-control mb1 comment-textarea"
           disabled={undefined}
           name="list-description"
-          onBlur={[Function]}
           onChange={[Function]}
           placeholder="Skriv kommentar"
           value=""
@@ -1112,6 +1112,7 @@ exports[`CommentContainer Component renders error 1`] = `
           </ProfileImage>
           <div
             className="form-group has-error"
+            onBlur={[Function]}
             onFocus={[Function]}
             style={
               Object {
@@ -1122,7 +1123,6 @@ exports[`CommentContainer Component renders error 1`] = `
             <textarea
               className="form-control mb1 comment-textarea"
               name="list-description"
-              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Skriv kommentar"
               value="comment3"
@@ -1136,8 +1136,8 @@ exports[`CommentContainer Component renders error 1`] = `
               className="tr"
               style={
                 Object {
-                  "height": "0px",
-                  "opacity": 0,
+                  "height": "50px",
+                  "opacity": 1,
                   "overflow": "hidden",
                   "transition": "all 200ms",
                 }
@@ -1428,6 +1428,7 @@ exports[`CommentContainer Component renders saving overlay 1`] = `
           </ProfileImage>
           <div
             className="form-group "
+            onBlur={[Function]}
             onFocus={[Function]}
             style={
               Object {
@@ -1438,7 +1439,6 @@ exports[`CommentContainer Component renders saving overlay 1`] = `
             <textarea
               className="form-control mb1 comment-textarea"
               name="list-description"
-              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Skriv kommentar"
               value=""
@@ -1764,6 +1764,7 @@ exports[`CommentContainer Toggle all comments 1`] = `
           </ProfileImage>
           <div
             className="form-group "
+            onBlur={[Function]}
             onFocus={[Function]}
             style={
               Object {
@@ -1774,7 +1775,6 @@ exports[`CommentContainer Toggle all comments 1`] = `
             <textarea
               className="form-control mb1 comment-textarea"
               name="list-description"
-              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Skriv kommentar"
               value=""
@@ -2152,6 +2152,7 @@ exports[`CommentContainer Toggle all comments 2`] = `
           </ProfileImage>
           <div
             className="form-group "
+            onBlur={[Function]}
             onFocus={[Function]}
             style={
               Object {
@@ -2162,7 +2163,6 @@ exports[`CommentContainer Toggle all comments 2`] = `
             <textarea
               className="form-control mb1 comment-textarea"
               name="list-description"
-              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Skriv kommentar"
               value=""

--- a/src/client/components/comments/__tests__/__snapshots__/CommentWrapper.test.js.snap
+++ b/src/client/components/comments/__tests__/__snapshots__/CommentWrapper.test.js.snap
@@ -1065,6 +1065,7 @@ exports[`CommentContainer Edit button 2`] = `
           >
             <div
               className="form-group "
+              onBlur={[Function]}
               onFocus={[Function]}
               style={
                 Object {
@@ -1076,7 +1077,6 @@ exports[`CommentContainer Edit button 2`] = `
                 autoFocus={true}
                 className="form-control mb1 comment-textarea"
                 name="list-description"
-                onBlur={[Function]}
                 onChange={[Function]}
                 placeholder="Skriv kommentar"
                 value="comment_test"
@@ -1085,8 +1085,8 @@ exports[`CommentContainer Edit button 2`] = `
                 className="tr"
                 style={
                   Object {
-                    "height": "0px",
-                    "opacity": 0,
+                    "height": "50px",
+                    "opacity": 1,
                     "overflow": "hidden",
                     "transition": "all 200ms",
                   }


### PR DESCRIPTION
Assure that the save button (Kommentér) is not hidden when blurring, and when there is content in the input field.
Furthermore fix a bug, where it was possible to leave the input field with the tabulator key, and still the save button was visible (for the Chrome browser) - even if the input field was empty.