### PR TITLE
#629 Rettelser efter test

### DIFF
--- a/src/client/components/work/FullTextReview.component.js
+++ b/src/client/components/work/FullTextReview.component.js
@@ -24,7 +24,6 @@ export default class FullTextReview extends React.Component {
       return '';
     }
     const reviewKeys = Object.keys(review.review);
-    var paragraphNumber = 0;
     return (
       <div className="Review__container mr-4 mb-5">
         <div className="Review__block--top">
@@ -41,13 +40,7 @@ export default class FullTextReview extends React.Component {
               <Title Tag="h6" type="title6" className="mb0">
                 {key === 'review' ? 'Vurdering' : key}
               </Title>
-              {paragraphNumber++ === 0 ? (
-                <Title Tag="h5" type="title5" className="mb2">
-                  {review.review[key]}
-                </Title>
-              ) : (
-                <Text type="body">{review.review[key]}</Text>
-              )}
+              <Text type="body">{review.review[key]}</Text>
             </React.Fragment>
           );
         })}

--- a/src/client/components/work/FullTextReview.component.js
+++ b/src/client/components/work/FullTextReview.component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {timestampToLongDate} from '../../utils/dateTimeFormat';
+import {timestampToShortDate} from '../../utils/dateTimeFormat';
 import './Review.css';
 import Title from '../base/Title';
 import Text from '../base/Text';
@@ -19,7 +19,7 @@ export default class FullTextReview extends React.Component {
     const surname = (review.reviewer && review.reviewer.surname) || '';
     const name = (firstname + ' ' + surname).trim(); // Trim the space away in case of missing first- or surname
     const date =
-      (review.creationDate && timestampToLongDate(review.creationDate)) || '';
+      (review.creationDate && timestampToShortDate(review.creationDate)) || '';
     if (typeof review.review === 'undefined' || review.review === null) {
       return '';
     }

--- a/src/client/components/work/FullTextReview.component.js
+++ b/src/client/components/work/FullTextReview.component.js
@@ -30,7 +30,7 @@ export default class FullTextReview extends React.Component {
           <Text type="micro" className="mb3">
             Bibliotekernes vurdering af {author}: {title}
           </Text>
-          <Text type="small" className="due-txt">
+          <Text type="small" className="due-txt date-col">
             {date}
           </Text>
         </div>

--- a/src/client/components/work/ResumeReview.component.js
+++ b/src/client/components/work/ResumeReview.component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {timestampToLongDate} from '../../utils/dateTimeFormat';
+import {timestampToShortDate} from '../../utils/dateTimeFormat';
 import './Review.css';
 import Title from '../base/Title';
 import Text from '../base/Text';
@@ -21,7 +21,7 @@ export class ResumeReview extends React.Component {
     const surname = (review.reviewer && review.reviewer.surname) || '';
     const name = (firstname + ' ' + surname).trim(); // Trim the space away in case of missing first- or surname
     const date =
-      (review.creationDate && timestampToLongDate(review.creationDate)) || '';
+      (review.creationDate && timestampToShortDate(review.creationDate)) || '';
     if (typeof review.review === 'undefined' || review.review === null) {
       return '';
     }

--- a/src/client/components/work/ResumeReview.component.js
+++ b/src/client/components/work/ResumeReview.component.js
@@ -46,7 +46,7 @@ export class ResumeReview extends React.Component {
               Af {name}
             </Text>
           )}
-        <Text type="body" className="mb0">
+        <Text type="body" className="Review__block--paragraph mb0">
           <em>
             <TruncateMarkup lines={3} ellipsis="...">
               <div>{reviewParagraph}</div>

--- a/src/client/components/work/Review.css
+++ b/src/client/components/work/Review.css
@@ -44,3 +44,7 @@
   justify-content: space-between;
 }
 
+.date-col {
+  min-width: 80px;
+  text-align: right;
+}

--- a/src/client/components/work/Review.css
+++ b/src/client/components/work/Review.css
@@ -48,3 +48,7 @@
   min-width: 80px;
   text-align: right;
 }
+
+.Review__block--paragraph {
+  font-size: 0.9em;
+}

--- a/src/client/components/work/__tests__/__snapshots__/FullTextReview.component.test.js.snap
+++ b/src/client/components/work/__tests__/__snapshots__/FullTextReview.component.test.js.snap
@@ -18,7 +18,7 @@ exports[`FullTextReview render function 1`] = `
     <p
       className="due-txt Text Text__small "
     >
-      2. marts 2005
+      2. mar 2005
     </p>
   </div>
   <h6
@@ -26,11 +26,11 @@ exports[`FullTextReview render function 1`] = `
   >
     Vurdering
   </h6>
-  <h5
-    className="mb2 Title Title__title5 "
+  <p
+    className=" Text Text__body "
   >
     Siden vinteren 2003 har DR1 i flere omgange sendt Hjerterum, en række meget sete programmer om boligindretning, hvor konceptet er, at to mennesker - ofte med meget forskellig smag - skal flytte sammen, og hvor en indretningsarkitekt med det bedste fra deres respektive indbo så indretter deres nye fælles hjem. Det er der kommet mange flotte, spændende og anderledes løsninger ud af, og i denne bog viser Vibeke Brinck, hvordan hun gjorde i fem konkrete tilfælde. Fælles for alle fem hjem er det personlige og individuelle frem for det meget strømlinede og arkitekttegnede. Der er dansk-svensk minimalisme, farvecollage på Nørrebro, stuelejlighed på Østerbro, taglejlighed i Århus og rækkehus på Amager. Der er inspirerende før-og-efter fotos, og der er masser af tips og ideer at hente til fornyelse eller opfriskning af de hjemlige stuer - både hvis det drejer sig om små effektfulde detaljer eller større projekter. Desuden er kapitler om farver, lys, møblering og materialer. Bogen lægger sig tæt op af udsendelserne, og er meget anvendelig til de mange lånere, der til stadighed efterspørger nyt om bogligindretning. En pendant til denne bog er Liselotte Risells bedste indretningsideer fra TV 2-succesen Helt solgt! (2003)
-  </h5>
+  </p>
   
   <p
     className="mb0 Text Text__body "
@@ -63,7 +63,7 @@ exports[`FullTextReview render function 2`] = `
     <p
       className="due-txt Text Text__small "
     >
-      6. marts 2017
+      6. mar 2017
     </p>
   </div>
   <h6
@@ -71,11 +71,11 @@ exports[`FullTextReview render function 2`] = `
   >
     Vurdering
   </h6>
-  <h5
-    className="mb2 Title Title__title5 "
+  <p
+    className=" Text Text__body "
   >
     En på alle måder stor roman af Hanne Marie Svendsen. I Sydvestgrønland lå der fra 985 til 1400-tallet en vidtstrakt nordisk bebyggelse med omkring 3.000 indbyggere, eget bispesæde og et munke- og et nonnekloster. Her lader Svendsen sin veloplagte, spændende og meget underholdende roman foregå. Den unge forældreløse Unn og hendes fostersøster Ingebjørg er under oplæring i nonneklosteret. Ingebjørg indordner sig, mens den mere rastløse Unn stiller en række nærmest kætterske spørgsmål til religionen og tilværelsen. Med Unn som hovedperson ledes man gennem romanens mange handlinger, og man møder en vrimmel af bipersoner. Der er lidenskabelige opgør, magtkampe og fejder, og middelalderens splittelse mellem hedensk overtro og religiøse skikke udspiller sig i et på én gang magisk og realistisk univers. Sprogligt er Unn fra Stjernestene holdt i sin egen tone og den beskriver den grønlandske natur flot og billedskabende. Lidenskab, tro og begærlighed er gennemgående temaer i den eventyrlige roman, som vil appellere til en stor læserkreds; dels læsere af historiske romaner i almindelighed, læsere af romaner med stærke kvindelige personligheder som f.eks. Dinas bog og sikkert også læsere af Ib Michael. Dystert grå-grønt-brunligt omslag
-  </h5>
+  </p>
   <h6
     className="mb0 Title Title__title6 "
   >
@@ -117,7 +117,7 @@ exports[`FullTextReview render function 3`] = `
     <p
       className="due-txt Text Text__small "
     >
-      11. august 2017
+      11. aug 2017
     </p>
   </div>
   <h6
@@ -125,11 +125,11 @@ exports[`FullTextReview render function 3`] = `
   >
     Kort om bogen
   </h6>
-  <h5
-    className="mb2 Title Title__title5 "
+  <p
+    className=" Text Text__body "
   >
     49-årige David har en stor stilling på en avis. En dag bryder David sammen og må genfinde sig selv i et lille sommerhus. Et hverdagsrealistisk drama om stress og kærlighed, der med fordel kan formidles til mandlige læsere
-  </h5>
+  </p>
   <h6
     className="mb0 Title Title__title6 "
   >
@@ -192,7 +192,7 @@ exports[`FullTextReview render function 4`] = `
     <p
       className="due-txt Text Text__small "
     >
-      6. marts 2017
+      6. mar 2017
     </p>
   </div>
   <h6
@@ -200,11 +200,11 @@ exports[`FullTextReview render function 4`] = `
   >
     Anvendelse/målgruppe/niveau
   </h6>
-  <h5
-    className="mb2 Title Title__title5 "
+  <p
+    className=" Text Text__body "
   >
     Rasmussens nyeste rammer lige ind i den fornyede interesse for 2. verdenskrig og den danske modstandsbevægelse. Omslaget signalerer ikke umiddelbart dette, men det sort/hvide fotografi af Sven er dog tidstypisk
-  </h5>
+  </p>
   <h6
     className="mb0 Title Title__title6 "
   >

--- a/src/client/components/work/__tests__/__snapshots__/FullTextReview.component.test.js.snap
+++ b/src/client/components/work/__tests__/__snapshots__/FullTextReview.component.test.js.snap
@@ -16,7 +16,7 @@ exports[`FullTextReview render function 1`] = `
       Den bedste indretning
     </p>
     <p
-      className="due-txt Text Text__small "
+      className="due-txt date-col Text Text__small "
     >
       2. mar 2005
     </p>
@@ -61,7 +61,7 @@ exports[`FullTextReview render function 2`] = `
       Nordisk halløj
     </p>
     <p
-      className="due-txt Text Text__small "
+      className="due-txt date-col Text Text__small "
     >
       6. mar 2017
     </p>
@@ -115,7 +115,7 @@ exports[`FullTextReview render function 3`] = `
       A
     </p>
     <p
-      className="due-txt Text Text__small "
+      className="due-txt date-col Text Text__small "
     >
       11. aug 2017
     </p>
@@ -190,7 +190,7 @@ exports[`FullTextReview render function 4`] = `
       Modstanden
     </p>
     <p
-      className="due-txt Text Text__small "
+      className="due-txt date-col Text Text__small "
     >
       6. mar 2017
     </p>

--- a/src/client/components/work/__tests__/__snapshots__/ResumeReview.component.test.js.snap
+++ b/src/client/components/work/__tests__/__snapshots__/ResumeReview.component.test.js.snap
@@ -25,7 +25,7 @@ exports[`ResumeReview render function 1`] = `
     Lone Krøgh
   </p>
   <p
-    className="mb0 Text Text__body "
+    className="Review__block--paragraph mb0 Text Text__body "
   >
     <em>
       <react-truncate-markup
@@ -77,7 +77,7 @@ exports[`ResumeReview render function 2`] = `
     Lone Krøgh
   </p>
   <p
-    className="mb0 Text Text__body "
+    className="Review__block--paragraph mb0 Text Text__body "
   >
     <em>
       <react-truncate-markup
@@ -129,7 +129,7 @@ exports[`ResumeReview render function 3`] = `
     Jacob Holm Krogsøe
   </p>
   <p
-    className="mb0 Text Text__body "
+    className="Review__block--paragraph mb0 Text Text__body "
   >
     <em>
       <react-truncate-markup
@@ -181,7 +181,7 @@ exports[`ResumeReview render function 4`] = `
     Per Månson
   </p>
   <p
-    className="mb0 Text Text__body "
+    className="Review__block--paragraph mb0 Text Text__body "
   >
     <em>
       <react-truncate-markup

--- a/src/client/components/work/__tests__/__snapshots__/ResumeReview.component.test.js.snap
+++ b/src/client/components/work/__tests__/__snapshots__/ResumeReview.component.test.js.snap
@@ -15,7 +15,7 @@ exports[`ResumeReview render function 1`] = `
     <p
       className="due-txt mb0 Text Text__small "
     >
-      2. marts 2005
+      2. mar 2005
     </p>
   </div>
   <p
@@ -67,7 +67,7 @@ exports[`ResumeReview render function 2`] = `
     <p
       className="due-txt mb0 Text Text__small "
     >
-      6. marts 2017
+      6. mar 2017
     </p>
   </div>
   <p
@@ -119,7 +119,7 @@ exports[`ResumeReview render function 3`] = `
     <p
       className="due-txt mb0 Text Text__small "
     >
-      11. august 2017
+      11. aug 2017
     </p>
   </div>
   <p
@@ -171,7 +171,7 @@ exports[`ResumeReview render function 4`] = `
     <p
       className="due-txt mb0 Text Text__small "
     >
-      6. marts 2017
+      6. mar 2017
     </p>
   </div>
   <p

--- a/src/client/utils/dateTimeFormat.js
+++ b/src/client/utils/dateTimeFormat.js
@@ -101,3 +101,17 @@ export function timestampToLongDate(timestamp) {
 
   return date + '. ' + month + ' ' + year;
 }
+
+/**
+ *
+ * @param timestamp
+ * @returns {string}
+ */
+export function timestampToShortDate(timestamp) {
+  const a = makeDate(timestamp);
+  const year = a.getFullYear();
+  const month = monthsShort[a.getMonth()];
+  const date = a.getDate();
+
+  return date + '. ' + month + ' ' + year;
+}


### PR DESCRIPTION
Peter havde følgende kommentarer:

- Første afsnit i lektørudtalelserne skal ikke være med semi-bold, da det giver uhensigtsmæssig visning af ældre lektørudtalelserne, hvor der kun er 1 langt semi-bold afsnit (se fx Erlend Loe - Doppler)
- Datoen for lektørudtalelserne på selve visningen skal anvende forkortelser og altid kunne være på én linie på mobilvisning
- I udfoldet visning (fra startsiden på desktop) er tekststørrelsen på lektørudtalelserne større end resten af indholdet (på den udfoldede visning). Tekststørrelsen på lektørudtalelserne skal derfor gøres mindre så de er samme størrelse. NOTE: det bør overvejes om man skal refaktorere udfoldet visning som komponenten matcher dem på værksiden, hvilket de ikke gør idag.

Formatet for anmeldelser fra Litteratursiden bør revurderes, da de nu skiller sig ret meget ud for lektørudtalelserne, som fremover også er standarden for andre anmeldelser. Der oprettes issue