### PR TITLE
make roles available in initial-state

### DIFF
--- a/src/client/redux/roles.reducer.js
+++ b/src/client/redux/roles.reducer.js
@@ -1,0 +1,21 @@
+const defaultState = {};
+
+export const ROLES_RESPONSE = 'ROLES_RESPONSE';
+
+const rolesReducer = (state = defaultState, action) => {
+  switch (action.type) {
+    case ROLES_RESPONSE: {
+      const nextState = {};
+      if (Array.isArray(action.roles)) {
+        action.roles.forEach(role => {
+          nextState[role.machineName] = role;
+        });
+      }
+      return nextState;
+    }
+    default:
+      return state;
+  }
+};
+
+export default rolesReducer;

--- a/src/client/redux/root.reducer.js
+++ b/src/client/redux/root.reducer.js
@@ -23,6 +23,7 @@ import scrollToComponent from './scrollToComponent';
 import matomo from './matomo.reducer';
 import animateReducer from './animate.reducer';
 import mountsReducer from './mounts.reducer';
+import rolesReducer from './roles.reducer';
 
 const combined = combineReducers({
   beltsReducer,
@@ -48,7 +49,8 @@ const combined = combineReducers({
   scrollToComponent,
   matomo,
   animateReducer,
-  mounts: mountsReducer
+  mounts: mountsReducer,
+  roles: rolesReducer
 });
 
 const rootReducer = (state = {}, action) => {

--- a/src/server/external-v1-initial-state.js
+++ b/src/server/external-v1-initial-state.js
@@ -9,6 +9,7 @@ import userReducer, {
 import interactionReducer, {
   FETCH_INTERACTIONS_SUCCESS
 } from '../client/redux/interaction.reducer';
+import rolesReducer, {ROLES_RESPONSE} from '../client/redux/roles.reducer';
 import orderReducer, {PREVIOUSLY_ORDERED} from '../client/redux/order.reducer';
 import beltsReducer, {BELTS_LOAD_RESPONSE} from '../client/redux/belts.reducer';
 import StorageClient from '../shared/server-side-storage.client';
@@ -35,6 +36,7 @@ async function initState(req) {
   let interactionState = interactionReducer(undefined, {});
   let orderState = orderReducer(undefined, {});
   let beltsState = beltsReducer(undefined, {});
+  let rolesState = rolesReducer(undefined, {});
 
   if (req.user) {
     userState = userReducer(userState, {
@@ -76,12 +78,15 @@ async function initState(req) {
     });
   }
 
+  const roles = (await objectStore.getAllRoles()).data;
+  rolesState = rolesReducer(rolesState, {type: ROLES_RESPONSE, roles});
   return {
     userReducer: userState,
     listReducer: listState,
     beltsReducer: beltsState,
     interactionReducer: interactionState,
-    orderReducer: orderState
+    orderReducer: orderState,
+    roles: rolesState
   };
 }
 

--- a/src/server/internal-v1-test.js
+++ b/src/server/internal-v1-test.js
@@ -231,7 +231,7 @@ const rootType = 'bf130fb7-8bd4-44fd-ad1d-43b6020ad102';
 let typeId;
 
 const admin = {
-  id: 'test_admin_id',
+  id: 'cf-admin',
   token: 'test_admin_token'
 };
 const user1 = {
@@ -286,7 +286,8 @@ router.route('/initStorage').get(
         name: 'role',
         machineName: 'contentFirstEditor',
         displayName: 'Læsekompasredaktør',
-        description: 'Redaktør for læsekompas'
+        description: 'Redaktør for læsekompas',
+        public: true
       }
     });
 

--- a/src/server/objectStore.js
+++ b/src/server/objectStore.js
@@ -6,6 +6,7 @@ const config = require('server/config');
 const request = require('superagent');
 const smaug = require('./smaug');
 
+const rootType = 'bf130fb7-8bd4-44fd-ad1d-43b6020ad102';
 let storageUrl;
 let aggregationUrl;
 let typeId;
@@ -322,6 +323,30 @@ async function getRoles(user) {
   }
 }
 
+async function getAllRoles() {
+  await validateObjectStore();
+  const requestObject = {
+    access_token: (await fetchAnonymousToken()).access_token,
+    scan: {
+      _type: rootType,
+      index: ['_owner', 'name'],
+      startsWith: ['cf-admin', 'role'],
+      expand: true
+    }
+  };
+
+  try {
+    const res = (await request
+      .post(storageUrl)
+      .send(requestObject)).body.data.map(role => fromStorageObject(role));
+    return {
+      data: res
+    };
+  } catch (e) {
+    return parseException(e);
+  }
+}
+
 function parseException(e) {
   if (e.status === 404) {
     return {
@@ -348,6 +373,7 @@ function parseException(e) {
 }
 
 module.exports = {
+  getAllRoles,
   getRoles,
   aggregation,
   getUser,


### PR DESCRIPTION
Man kan nu slå et id på en rolle op ud fra machineName. Data ligger i redux state fra start - også selvom brugeren ikke er logget ind - eller at brugeren ikke har den rolle:

state.roles.contentFirstEditor._id

Kan så bruges til at hente belts ud der tilhører den rolle