### PR TITLE
CF-1274-appeals (patch)

### DIFF
--- a/src/client/components/base/Expand/Expand.css
+++ b/src/client/components/base/Expand/Expand.css
@@ -4,7 +4,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  background: linear-gradient(transparent, white 60%);
+  background: linear-gradient(transparent 70%, white 90%);
   justify-content: center;
   z-index: 2;
   pointer-events: none;

--- a/src/client/components/base/T/T.json
+++ b/src/client/components/base/T/T.json
@@ -133,6 +133,10 @@
       "showMore": {
         "da": "Vis mere",
         "en": "Show more"
+      },
+      "particularlyProminent": {
+        "da": "Særligt fremtrædende",
+        "en": "Particularly prominent"
       }
     },
     "login": {

--- a/src/client/components/belteditor/CreateBelt.component.js
+++ b/src/client/components/belteditor/CreateBelt.component.js
@@ -47,7 +47,6 @@ export class CreateBelt extends React.Component {
     }
     const result = {...this.state, tags: this.props.tags.map(item => item.id)};
     create(result);
-    console.log('CreateBelt Result', result);
     window.open('/redaktionen', '_self');
   };
 

--- a/src/client/components/work/WorkPage/WorkPage.container.js
+++ b/src/client/components/work/WorkPage/WorkPage.container.js
@@ -440,9 +440,11 @@ class WorkPage extends React.Component {
                     className="tabs tabs-page-2"
                   >
                     {appeals.length > 0 ? (
-                      <div className={`WorkPage__tabs-info`}>
+                      <div className="WorkPage__tabs-info">
                         <div className="WorkPage__tabs-info-color" />
-                        <Text type="small">{'Særligt fremtrædende'}</Text>
+                        <Text type="small">
+                          <T component="general" name="particularlyProminent" />
+                        </Text>
                       </div>
                     ) : (
                       <Text type="body" className="Compare_noTags">

--- a/src/client/components/work/WorkPage/WorkPage.container.js
+++ b/src/client/components/work/WorkPage/WorkPage.container.js
@@ -52,6 +52,7 @@ class WorkPage extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.pid !== prevProps.pid) {
       this.init();
+      this.swiper.slideTo(0, 0);
     }
   }
 
@@ -377,7 +378,7 @@ class WorkPage extends React.Component {
                     })}
                   </div>
 
-                  {book.tags.length > 0 && (
+                  {appeals.length > 0 && (
                     <div className="row">
                       <div className="mt1 col-12">
                         <Button
@@ -388,6 +389,9 @@ class WorkPage extends React.Component {
                           onClick={() => {
                             trackEvent('tags', 'seeAllTags', book.title);
                             this.swiper.slideTo(1, 400);
+                            this.setState({
+                              tabsCollapsed: false
+                            });
                           }}
                         >
                           <T component="work" name={'tagsCollapsibleShow'} />
@@ -408,8 +412,7 @@ class WorkPage extends React.Component {
                     title={T({component: 'general', name: 'showMore'})}
                     onClick={() => {
                       this.setState({
-                        tabsCollapsed: !this.state.tabsCollapsed,
-                        transition: true
+                        tabsCollapsed: false
                       });
                     }}
                   />
@@ -436,6 +439,16 @@ class WorkPage extends React.Component {
                     data-cy="tabs-page-Læseoplevelse"
                     className="tabs tabs-page-2"
                   >
+                    {appeals.length > 0 ? (
+                      <div className={`WorkPage__tabs-info`}>
+                        <div className="WorkPage__tabs-info-color" />
+                        <Text type="small">{'Særligt fremtrædende'}</Text>
+                      </div>
+                    ) : (
+                      <Text type="body" className="Compare_noTags">
+                        <T component="work" name="noAppeals" />
+                      </Text>
+                    )}
                     {appeals.map(group => {
                       return (
                         <React.Fragment key={group.title}>

--- a/src/client/components/work/WorkPage/WorkPage.css
+++ b/src/client/components/work/WorkPage/WorkPage.css
@@ -146,6 +146,18 @@
   background-color: var(--pistache);
 }
 
+.WorkPage__tabs-info {
+  display: flex;
+  align-items: center;
+}
+
+.WorkPage__tabs-info-color {
+  width: 40px;
+  height: 16px;
+  background-color: var(--pistache);
+  margin: 0 8px 0 0;
+}
+
 .review_list__review {
   display: flex;
   justify-content: space-between;

--- a/src/client/components/work/WorkPreview/WorkPreview.component.js
+++ b/src/client/components/work/WorkPreview/WorkPreview.component.js
@@ -32,13 +32,12 @@ class WorkPreview extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      tabsCollapsed: true,
-      transition: true
+      tabsCollapsed: true
     };
   }
 
   init() {
-    this.setState({tabsCollapsed: true, transition: false});
+    this.setState({tabsCollapsed: true});
   }
 
   componentDidMount() {
@@ -282,8 +281,7 @@ class WorkPreview extends React.Component {
                   title={T({component: 'general', name: 'showMore'})}
                   onClick={() => {
                     this.setState({
-                      tabsCollapsed: !this.state.tabsCollapsed,
-                      transition: true
+                      tabsCollapsed: false
                     });
                   }}
                 />
@@ -303,6 +301,18 @@ class WorkPreview extends React.Component {
                 />
               </div>
               <div className="tabs tabs-page-2">
+                {appeals.length > 0 ? (
+                  <div className="workPreview__tabs-info">
+                    <div className="workPreview__tabs-info-color" />
+                    <Text type="small">
+                      <T component="general" name="particularlyProminent" />
+                    </Text>
+                  </div>
+                ) : (
+                  <Text type="body" className="Compare_noTags">
+                    <T component="work" name="noAppeals" />
+                  </Text>
+                )}
                 {appeals.map(group => {
                   return (
                     <React.Fragment key={group.title}>

--- a/src/client/components/work/WorkPreview/WorkPreview.css
+++ b/src/client/components/work/WorkPreview/WorkPreview.css
@@ -120,6 +120,18 @@
   background-color: var(--pistache);
 }
 
+.workPreview__tabs-info {
+  display: flex;
+  align-items: center;
+}
+
+.workPreview__tabs-info-color {
+  width: 40px;
+  height: 16px;
+  background-color: var(--pistache);
+  margin: 0 8px 0 0;
+}
+
 /*  tags */
 
 .workPreview__reviews .workPreview__tag {

--- a/src/client/redux/books.reducer.js
+++ b/src/client/redux/books.reducer.js
@@ -1,8 +1,21 @@
-import {merge, get, uniqBy} from 'lodash';
+import {merge, get} from 'lodash';
 
 const defaultState = {
   books: {}
 };
+
+function mergeTags(oldTags, newTags) {
+  const result = {};
+
+  oldTags.forEach(tag => (result[tag.id] = tag));
+  newTags.forEach(tag => {
+    if (!result[tag.id] || tag.score) {
+      result[tag.id] = tag;
+    }
+  });
+
+  return Object.values(result);
+}
 
 export const BOOKS_REQUEST = 'BOOKS_REQUEST';
 export const BOOKS_RESPONSE = 'BOOKS_RESPONSE';
@@ -17,8 +30,9 @@ const booksReducer = (state = defaultState, action) => {
         const pid = b.book.pid;
         const oldTags = get(books[pid], 'book.tags', []);
         const newTags = get(b, 'book.tags', []);
+
         books[pid] = merge({}, books[pid], b, {
-          book: {tags: uniqBy([...oldTags, ...newTags], 'id')}
+          book: {tags: mergeTags(oldTags, newTags)}
         });
       });
       return Object.assign({}, state, {books: books});


### PR DESCRIPTION
Fixes til CF-1274-appeals:

Rasmus' kommentarer fra tidligere test, som gerne skulle være løst i denne "patch".

Vedr. CF-1274: OK på staging, at klik på "Se hele læseoplevelsen" får panelet til at skøjte over på "Læseoplevelse". Men:
870970-basis:25039505 har tagget "Den 2. verdenskrig" under "Minder om", men ikke i panelet.
870970-basis:21065986 har ingen tags under "Minder om", men flere tags i panelet.
870970-basis:52623723 har hverken tags under "Minder om" eller i panelet, men knappen "Se hele læseoplevelsen" vises alligevel. Panelet skulle måske have en tekst ala "Vi har ikke nogen beskrivelse af bogen".
Der ses ingen forklaring på, hvorfor nogle tags er grønne. Man kan tro, at kun de grønne gælder for bogen.
Hvis der er mange tags i panelet, skal man klikke "Vis mere" efter klik på "Se hele læseoplevelsen". Måske skulle alle tags blive vist med det samme, når man klikker "Se hele læseoplevelsen"?