### PR TITLE
use content-first timestamps until storage native timestamps are migr…

### DIFF
--- a/src/server/objectStore.js
+++ b/src/server/objectStore.js
@@ -122,6 +122,19 @@ const fromStorageObject = storageObject => {
       copy[key] = value;
     }
   });
+
+  // TODO remove when storage contains native timestamps
+  copy._created = storageObject.cf_created;
+  copy._modified = storageObject.cf_modified;
+
+  // TODO comment in when storage contains native timestamps
+  // storageObject._created = Math.floor(
+  //   Date.parse(storageObject._created) / 1000
+  // );
+  // storageObject._modified = Math.floor(
+  //   Date.parse(storageObject._version) / 1000
+  // );
+
   return copy;
 };
 


### PR DESCRIPTION
…ated

Når _created bliver håndteret i storage - vil der være en periode hvor _created vil være sat til det tidspunkt hvor created-kolonnen oprettes. Indtil data er kopieret fra cf_created skal vi sikre os at cf_created overskriver _created i content-first.