### PR TITLE
update mock data to fix order tests

### DIFF
--- a/e2e/cypress/fixtures/order/canorderawork.mock.json
+++ b/e2e/cypress/fixtures/order/canorderawork.mock.json
@@ -423,17 +423,24 @@
     ],
     "timing": 0
   },
-  "_availability_{\"pids\":[\"870970-basis:54154313\"]}": {
+  "_availability_{\"pids\":[\"870970-basis:54154313\",\"870970-basis:46081994\"]}": {
     "data": [
       {
-        "willLend": false,
+        "willLend": true,
+        "expectedDelivery": "2019-09-26T00:00:00+02:00",
         "orderPossible": true,
-        "orderPossibleReason": "not_owned_ILL_loc"
+        "orderPossibleReason": "owned_accepted"
+      },
+      {
+        "willLend": true,
+        "expectedDelivery": "2019-10-19T00:00:00+02:00",
+        "orderPossible": true,
+        "orderPossibleReason": "owned_accepted"
       }
     ],
     "timing": 0
   },
-  "_order_{\"pids\":[\"870970-basis:54154313\"],\"pickUpBranch\":\"790900\"}": {
+  "_order_{\"pids\":[\"870970-basis:54154313\",\"870970-basis:46081994\"],\"pickUpBranch\":\"790900\"}": {
     "data": {
       "status": "ok",
       "orsId": "1034785015"

--- a/e2e/cypress/fixtures/order/orderbuttondisabledwhileloadingavailability.mock.json
+++ b/e2e/cypress/fixtures/order/orderbuttondisabledwhileloadingavailability.mock.json
@@ -423,12 +423,19 @@
     ],
     "timing": 0
   },
-  "_availability_{\"pids\":[\"870970-basis:54154313\"]}": {
+  "_availability_{\"pids\":[\"870970-basis:54154313\",\"870970-basis:46081994\"]}": {
     "data": [
       {
-        "willLend": false,
+        "willLend": true,
+        "expectedDelivery": "2019-09-26T00:00:00+02:00",
         "orderPossible": true,
-        "orderPossibleReason": "not_owned_ILL_loc"
+        "orderPossibleReason": "owned_accepted"
+      },
+      {
+        "willLend": true,
+        "expectedDelivery": "2019-10-19T00:00:00+02:00",
+        "orderPossible": true,
+        "orderPossibleReason": "owned_accepted"
       }
     ],
     "timing": 5000

--- a/e2e/cypress/fixtures/order/orderbuttondisabledwhileloadinguser.mock.json
+++ b/e2e/cypress/fixtures/order/orderbuttondisabledwhileloadinguser.mock.json
@@ -423,12 +423,19 @@
     ],
     "timing": 0
   },
-  "_availability_{\"pids\":[\"870970-basis:54154313\"]}": {
+  "_availability_{\"pids\":[\"870970-basis:54154313\",\"870970-basis:46081994\"]}": {
     "data": [
       {
-        "willLend": false,
+        "willLend": true,
+        "expectedDelivery": "2019-09-26T00:00:00+02:00",
         "orderPossible": true,
-        "orderPossibleReason": "not_owned_ILL_loc"
+        "orderPossibleReason": "owned_accepted"
+      },
+      {
+        "willLend": true,
+        "expectedDelivery": "2019-10-19T00:00:00+02:00",
+        "orderPossible": true,
+        "orderPossibleReason": "owned_accepted"
       }
     ],
     "timing": 0

--- a/e2e/cypress/integration/order.spec.js
+++ b/e2e/cypress/integration/order.spec.js
@@ -24,6 +24,7 @@ describe('Order ', function() {
     cy.visit('/v%C3%A6rk/' + pid);
 
     cy.get('[data-cy=order-btn]').click();
+    cy.contains('Kan bestilles');
     cy.get('[data-cy=modal-done-btn]').click();
     cy.get('[data-cy=order-status]').should('have.text', '1 bog er bestilt');
   });


### PR DESCRIPTION
Der var lige nogle cypress tests der fejlede. Jeg har ikke demo'et openplatform-mock-recorder jeg har bikset sammen, så jeg har optaget noget ny mock-data.

Der bliver nu sendt to pid'er i order-requestet, er det fint?