### PR TITLE
only render relevant components wrapped by withHoldings

### DIFF
--- a/src/client/components/hoc/Holding/withHoldings.hoc.js
+++ b/src/client/components/hoc/Holding/withHoldings.hoc.js
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {useDispatch, useSelector, shallowEqual} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {fetchHoldings} from '../../../redux/holdings.thunk';
 
 /**

--- a/src/client/components/hoc/Holding/withHoldings.hoc.js
+++ b/src/client/components/hoc/Holding/withHoldings.hoc.js
@@ -9,11 +9,11 @@ import {fetchHoldings} from '../../../redux/holdings.thunk';
  * @param {object} pid - The pid for the material to fetch Holdings for
  * @return {object} - returns the Holdings
  **/
-
 export const withHoldings = WrappedComponent => props => {
   const {agencyId, branch, pid} = props;
   const [hasDispatched, setHasDispatched] = useState(false);
-  const {holdings} = useSelector(store => store.holdings, shallowEqual);
+
+  const holdings = useSelector(store => store.holdings.holdings[pid]);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -23,7 +23,7 @@ export const withHoldings = WrappedComponent => props => {
     }
   }, [agencyId, branch, pid, dispatch, hasDispatched]);
 
-  return <WrappedComponent pid={pid} holdings={holdings[pid]} />;
+  return <WrappedComponent pid={pid} holdings={holdings} />;
 };
 
 export default withHoldings;


### PR DESCRIPTION
Det vigtige her er at det der hentes ud med useSelector er så specifikt som muligt. På den måde vil hver holding-state-change ikke medføre at alle komponenter wrapped af withHoldings bliver renderet. Dvs hvis man har 100 komponenter vil der blive lavet ca 100*100 renderinger hvis de hver henter holdings ud én gang. Det kan altså hurtigt løbe løbsk. Vi skal gerne holde den til 100 renderinger.

Derudover er det ikke nødvendigt med shallowEqual - som er meget langsommere end et simpelt "strict equality check", som useSelector bruger som default.