### PR TITLE
Bugfix: To adapt to new tags recommender

### DIFF
--- a/src/lib/services/recompas-tags.js
+++ b/src/lib/services/recompas-tags.js
@@ -54,7 +54,7 @@ class RecompasTags {
       let status;
       if (agencyId && branch) {
         branchid = `${agencyId}|${
-          branch.match(/^".*"$/) ? branch : `"${branch}"`
+          branch.match(/^".*"$/) ? branch : `'${branch}'`
         }`;
         status = 'onShelf';
       }


### PR DESCRIPTION
Den nye tags recommender forlanger (åbenbart) single quotes og vil ikke acceptere double quotes omkring branch navnet
